### PR TITLE
Created Transformers and validators for easy constraint resolution.

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
 kotlin.code.style=official
 ktor_version=1.2.3
 logback_version=1.2.1
-kotlin_version=1.3.30
+kotlin_version=1.3.50

--- a/src/main/kotlin/com/papsign/ktor/openapigen/OpenAPIGenExtension.kt
+++ b/src/main/kotlin/com/papsign/ktor/openapigen/OpenAPIGenExtension.kt
@@ -1,0 +1,5 @@
+package com.papsign.ktor.openapigen
+
+interface OpenAPIGenExtension {
+    fun onInit(gen: OpenAPIGen)
+}

--- a/src/main/kotlin/com/papsign/ktor/openapigen/OpenAPIGenModuleExtension.kt
+++ b/src/main/kotlin/com/papsign/ktor/openapigen/OpenAPIGenModuleExtension.kt
@@ -1,0 +1,13 @@
+package com.papsign.ktor.openapigen
+
+import com.papsign.ktor.openapigen.modules.OpenAPIModule
+
+/**
+ * implement this to automatically register an object as [OpenAPIModule] in the global context
+ * only works if the object is in a package declared in [OpenAPIGen.Configuration.scanPackagesForModules]
+ */
+interface OpenAPIGenModuleExtension: OpenAPIModule, OpenAPIGenExtension {
+    override fun onInit(gen: OpenAPIGen) {
+        gen.globalModuleProvider.registerModule(this)
+    }
+}

--- a/src/main/kotlin/com/papsign/ktor/openapigen/annotations/encodings/APIFormatter.kt
+++ b/src/main/kotlin/com/papsign/ktor/openapigen/annotations/encodings/APIFormatter.kt
@@ -1,9 +1,0 @@
-package com.papsign.ktor.openapigen.annotations.encodings
-
-/**
- * must be applied to parser or serializer object, or annotation to mark it as Encoding Selector
- */
-@Target(AnnotationTarget.CLASS)
-@Retention(AnnotationRetention.RUNTIME)
-annotation class APIFormatter
-

--- a/src/main/kotlin/com/papsign/ktor/openapigen/content/type/binary/BinaryContentTypeParser.kt
+++ b/src/main/kotlin/com/papsign/ktor/openapigen/content/type/binary/BinaryContentTypeParser.kt
@@ -4,8 +4,8 @@ import com.papsign.kotlin.reflection.getKType
 import com.papsign.kotlin.reflection.getObjectSubtypes
 import com.papsign.kotlin.reflection.unitKType
 import com.papsign.ktor.openapigen.OpenAPIGen
+import com.papsign.ktor.openapigen.OpenAPIGenModuleExtension
 import com.papsign.ktor.openapigen.annotations.Response
-import com.papsign.ktor.openapigen.annotations.encodings.APIFormatter
 import com.papsign.ktor.openapigen.content.type.BodyParser
 import com.papsign.ktor.openapigen.content.type.ContentTypeProvider
 import com.papsign.ktor.openapigen.content.type.ResponseSerializer
@@ -30,8 +30,7 @@ import kotlin.reflect.full.declaredMemberProperties
 import kotlin.reflect.full.findAnnotation
 import kotlin.reflect.jvm.jvmErasure
 
-@APIFormatter
-object BinaryContentTypeParser: BodyParser, ResponseSerializer {
+object BinaryContentTypeParser: BodyParser, ResponseSerializer, OpenAPIGenModuleExtension {
 
     override fun <T : Any> getParseableContentTypes(clazz: KClass<T>): List<ContentType> {
         return clazz.findAnnotation<BinaryRequest>()?.contentTypes?.map(ContentType.Companion::parse) ?: listOf()

--- a/src/main/kotlin/com/papsign/ktor/openapigen/content/type/ktor/KtorContentProvider.kt
+++ b/src/main/kotlin/com/papsign/ktor/openapigen/content/type/ktor/KtorContentProvider.kt
@@ -4,7 +4,7 @@ import com.papsign.kotlin.reflection.allTypes
 import com.papsign.kotlin.reflection.getKType
 import com.papsign.kotlin.reflection.unitKType
 import com.papsign.ktor.openapigen.OpenAPIGen
-import com.papsign.ktor.openapigen.annotations.encodings.APIFormatter
+import com.papsign.ktor.openapigen.OpenAPIGenModuleExtension
 import com.papsign.ktor.openapigen.annotations.encodings.APIRequestFormat
 import com.papsign.ktor.openapigen.annotations.encodings.APIResponseFormat
 import com.papsign.ktor.openapigen.content.type.BodyParser
@@ -36,8 +36,7 @@ import kotlin.reflect.jvm.jvmErasure
 /**
  * default content provider using the ktor pipeline to handle the serialization and deserialization
  */
-@APIFormatter
-object KtorContentProvider : ContentTypeProvider, BodyParser, ResponseSerializer {
+object KtorContentProvider : ContentTypeProvider, BodyParser, ResponseSerializer, OpenAPIGenModuleExtension {
 
     private val arrayType = getKType<ByteArray>()
     private var contentNegotiation: ContentNegotiation? = null

--- a/src/main/kotlin/com/papsign/ktor/openapigen/content/type/multipart/MultipartFormDataContentProvider.kt
+++ b/src/main/kotlin/com/papsign/ktor/openapigen/content/type/multipart/MultipartFormDataContentProvider.kt
@@ -4,7 +4,7 @@ import com.papsign.kotlin.reflection.getKType
 import com.papsign.kotlin.reflection.getObjectSubtypes
 import com.papsign.kotlin.reflection.unitKType
 import com.papsign.ktor.openapigen.OpenAPIGen
-import com.papsign.ktor.openapigen.annotations.encodings.APIFormatter
+import com.papsign.ktor.openapigen.OpenAPIGenModuleExtension
 import com.papsign.ktor.openapigen.content.type.BodyParser
 import com.papsign.ktor.openapigen.content.type.ContentTypeProvider
 import com.papsign.ktor.openapigen.exceptions.assertContent
@@ -30,8 +30,7 @@ import kotlin.reflect.full.primaryConstructor
 import kotlin.reflect.full.withNullability
 import kotlin.reflect.jvm.jvmErasure
 
-@APIFormatter
-object MultipartFormDataContentProvider : BodyParser {
+object MultipartFormDataContentProvider : BodyParser, OpenAPIGenModuleExtension {
 
     override fun <T : Any> getParseableContentTypes(clazz: KClass<T>): List<ContentType> {
         return listOf(ContentType.MultiPart.FormData)

--- a/src/main/kotlin/com/papsign/ktor/openapigen/validators/LowerCase.kt
+++ b/src/main/kotlin/com/papsign/ktor/openapigen/validators/LowerCase.kt
@@ -1,0 +1,14 @@
+package com.papsign.ktor.openapigen.validators
+
+import com.papsign.ktor.openapigen.validators.util.AValidator
+
+@Retention(AnnotationRetention.RUNTIME)
+@Target(AnnotationTarget.PROPERTY)
+@ValidationAnnotation
+annotation class LowerCase
+
+object LowerCaseValidator : AValidator<String, LowerCase>(String::class, LowerCase::class) {
+    override fun validate(subject: String?, annotation: LowerCase): String? {
+        return subject?.toLowerCase()
+    }
+}

--- a/src/main/kotlin/com/papsign/ktor/openapigen/validators/Trim.kt
+++ b/src/main/kotlin/com/papsign/ktor/openapigen/validators/Trim.kt
@@ -1,0 +1,14 @@
+package com.papsign.ktor.openapigen.validators
+
+import com.papsign.ktor.openapigen.validators.util.AValidator
+
+@Retention(AnnotationRetention.RUNTIME)
+@Target(AnnotationTarget.PROPERTY)
+@ValidationAnnotation
+annotation class Trim
+
+object TrimValidator : AValidator<String, Trim>(String::class, Trim::class) {
+    override fun validate(subject: String?, annotation: Trim): String? {
+        return subject?.trim()
+    }
+}

--- a/src/main/kotlin/com/papsign/ktor/openapigen/validators/ValidationAnnotation.kt
+++ b/src/main/kotlin/com/papsign/ktor/openapigen/validators/ValidationAnnotation.kt
@@ -1,0 +1,5 @@
+package com.papsign.ktor.openapigen.validators
+
+@Retention(AnnotationRetention.RUNTIME)
+@Target(AnnotationTarget.ANNOTATION_CLASS)
+annotation class ValidationAnnotation

--- a/src/main/kotlin/com/papsign/ktor/openapigen/validators/ValidationHandler.kt
+++ b/src/main/kotlin/com/papsign/ktor/openapigen/validators/ValidationHandler.kt
@@ -1,0 +1,85 @@
+package com.papsign.ktor.openapigen.validators
+
+import com.papsign.kotlin.reflection.getKType
+import com.papsign.ktor.openapigen.classLogger
+import com.papsign.ktor.openapigen.modules.ModuleProvider
+import com.papsign.ktor.openapigen.modules.ofClass
+import java.lang.Error
+import java.lang.Exception
+import kotlin.reflect.*
+import kotlin.reflect.full.functions
+import kotlin.reflect.full.instanceParameter
+import kotlin.reflect.full.memberProperties
+import kotlin.reflect.jvm.jvmErasure
+
+class ValidationHandler<T>(type: KType, context: ModuleProvider<*>) {
+    private val log = classLogger()
+
+    private val transformFun: ((T) -> T)?
+    init {
+        val validators = context.ofClass<Validator<Any, Annotation>>()
+        val eligibleProperties = try { type.jvmErasure.memberProperties } catch (e: Error) { listOf<KProperty1<T, *>>() }
+        val targets = eligibleProperties.associateWith { prop ->
+            val annotations = prop.annotations.map { it.annotationClass }.toSet()
+            val handler = ValidationHandler<Any?>(prop.returnType, context)
+            val appliedValidators = validators.filter {
+                val applied = (annotations as Set<KClass<Annotation>>).contains(it.annotationClass)
+                if (applied && !it.isTypeSupported(prop.returnType.jvmErasure)) {
+                    log.error("Validator ${it::class.simpleName} does not support type ${prop.returnType} of $prop and will be ignored")
+                    false
+                } else {
+                    applied
+                }
+            }.associateWith {
+                prop.annotations.filter { annot -> it.annotationClass.isInstance(annot) }
+            }
+            val validations = appliedValidators.flatMap { (valid, annots) ->
+                annots.map { annot ->
+                    log.trace("Applying validator ${valid::class} with $annot on $prop");
+                    { t: Any? -> valid.validate(t, annot) }
+                }
+            }
+            if (validations.isNotEmpty()) {
+                if (handler.isUseful()) {
+                    { t: Any? -> validations.fold(handler.handle(t)) { v, op -> op(v) } }
+                } else {
+                    { t: Any? -> validations.fold(t) { v, op -> op(v) } }
+                }
+            } else {
+                if (handler.isUseful()) {
+                    handler::handle
+                } else {
+                    null
+                }
+            }
+        }.filterValues { it != null } as Map<KProperty1<T, *>, (Any?) -> Any?>
+        transformFun = when {
+            targets.isEmpty() -> null
+            type.jvmErasure.isData -> {
+                val copy = type.jvmErasure.functions.find { it.name == "copy" } as KFunction<T>
+                val propMap = copy.parameters.associateBy { it.name }
+                val mapped = targets.map { (prop, fn) -> Pair(propMap[prop.name]!!, Pair(prop, fn)) }.associate { it }
+                val instanceParam = copy.instanceParameter!!
+                { t: T -> if (t != null) copy.callBy(mapOf(instanceParam to t) + mapped.mapValues { it.value.second(it.value.first.get(t)) }) else t }
+            }
+            else -> {
+                log.error("Validators are only supported on data classes, tried on: $type")
+                null
+            }
+        }
+    }
+
+    fun handle(t: T): T {
+        return if (t != null) transformFun?.invoke(t) ?: t else t
+    }
+
+    fun isUseful(): Boolean {
+        return transformFun != null
+    }
+
+    companion object {
+        inline operator fun <reified T : Any> invoke(provider: ModuleProvider<*>): ValidationHandler<T> {
+            return ValidationHandler(getKType<T>(), provider)
+        }
+    }
+}

--- a/src/main/kotlin/com/papsign/ktor/openapigen/validators/Validator.kt
+++ b/src/main/kotlin/com/papsign/ktor/openapigen/validators/Validator.kt
@@ -1,0 +1,17 @@
+package com.papsign.ktor.openapigen.validators
+
+import com.papsign.ktor.openapigen.modules.OpenAPIModule
+import org.jetbrains.annotations.Contract
+import kotlin.reflect.KClass
+
+interface Validator<T: Any, A: Annotation>: OpenAPIModule {
+    fun isTypeSupported(clazz: KClass<*>): Boolean
+    val annotationClass: KClass<A>
+    val exceptionClasses: List<KClass<*>>
+    /**
+     * [subject] the serialized property
+     * [annotation] the annotation instance on the property
+     * @return the transformed property or [subject] if unchanged
+     */
+    fun validate(subject: T?, annotation: A): T?
+}

--- a/src/main/kotlin/com/papsign/ktor/openapigen/validators/util/AValidator.kt
+++ b/src/main/kotlin/com/papsign/ktor/openapigen/validators/util/AValidator.kt
@@ -1,0 +1,15 @@
+package com.papsign.ktor.openapigen.validators.util
+
+import com.papsign.ktor.openapigen.OpenAPIGenModuleExtension
+import com.papsign.ktor.openapigen.validators.Validator
+import kotlin.reflect.KClass
+import kotlin.reflect.full.isSubclassOf
+
+
+abstract class AValidator<T : Any, A : Annotation>(val t: KClass<T>, a: KClass<A>) : Validator<T, A>, OpenAPIGenModuleExtension {
+    override fun isTypeSupported(clazz: KClass<*>): Boolean {
+        return clazz.isSubclassOf(t)
+    }
+    override val annotationClass: KClass<A> = a
+    override val exceptionClasses: List<KClass<*>> = listOf()
+}


### PR DESCRIPTION
Added support for transforming and validating annotations during serialization.

Currently Supported:
@LowerCase applies .toLowerCase on String
@Trim applies .trim on String

New validators can be added by declaring a new openapi module in the search path: 

in the config:
```kotlin
install(OpenAPIGen) {
    ...
    scanPackagesForModules = arrayOf("com.example")
}
```

in `com.example.TestValidator`
```kotlin
@Retention(AnnotationRetention.RUNTIME)
@Target(AnnotationTarget.PROPERTY)
annotation class TestAnnot

object AnyValidator : AValidator<Any, TestAnnot>(Any::class, TestAnnot::class) {
    override fun validate(subject: Any?, annotation: TestAnnot): Any? {
        println(subject)
        // return transformed object or throw exceptions that you will handle with the route exception handlers
        return subject
    }
}
```