### PR TITLE
make Nothing provider provide nullable Nothing

### DIFF
--- a/src/main/kotlin/com/papsign/ktor/openapigen/schema/builder/provider/NothingSchemaProvider.kt
+++ b/src/main/kotlin/com/papsign/ktor/openapigen/schema/builder/provider/NothingSchemaProvider.kt
@@ -14,8 +14,14 @@ import kotlin.reflect.jvm.jvmErasure
 
 object NothingSchemaProvider: SchemaBuilderProviderModule, OpenAPIGenModuleExtension {
 
+    private object NothingNullableProvider {
+        private val value: Nothing? = null
+        val type: KType = this::value.returnType
+    }
+
     private object Builder: SchemaBuilder {
-        override val superType: KType = Nothing::class.createType()
+        // Currently we can't do it in a more concise way because of https://youtrack.jetbrains.com/issue/KT-37848
+        override val superType: KType = NothingNullableProvider.type
 
         override fun build(
             type: KType,


### PR DESCRIPTION
Follow up of #26.

Thank you, but you variant puts `java.lang.Void` in the map so my `kotlin.Nothing?` isn't its subtype. I've made some changes and they work for me. Could you accept them to the main repo?