### PR TITLE
Update swaggerui, make its version configurable, minor readme update

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,13 +10,16 @@ Ktor OpenAPI Generator is:
 - Explicit
 
 Currently Supported:
-- Authentication ineroperability with strongly typed Principal (OAuth only, see TestServer in tests)
-- Content Negociation interoperability (see TestServer in tests)
-- Custom response codes (as parameter in @Response)
-- Automatic and custom content Type routing and parsing (see com.papsign.ktor.openapigen.content.type, Binary Parser and default JSON parser (that uses the ktor implicit parsing/serializing))
-- Exception handling (use .throws(ex) {} in the routes with an APIException object) with Status pages interop (with .withAPI in the StatusPages configuration)
-- tags (.tag(tag) {} in route with a tag object, currently must be an enum, but may be subject to change)
+- Authentication interoperability with strongly typed Principal (OAuth only, see TestServer in tests)
+- Content Negotiation interoperability (see TestServer in tests)
+- Custom response codes (as parameter in `@Response`)
+- Automatic and custom content Type routing and parsing (see `com.papsign.ktor.openapigen.content.type`, Binary Parser and default JSON parser (that uses the ktor implicit parsing/serializing))
+- Exception handling (use `.throws(ex) {}` in the routes with an APIException object) with Status pages interop (with .withAPI in the StatusPages configuration)
+- tags (`.tag(tag) {}` in route with a tag object, currently must be an enum, but may be subject to change)
 - Spec compliant Parameter Parsing (see basic example)
+
+Extra Features:
+- Includes Swagger-UI (enabled by default, can be managed in the `install(OpenAPIGen) { ... }` section)
 
 It is inspired by ktor Locations, but makes no use of it.
 
@@ -26,7 +29,7 @@ Take a look at the [wiki for advanced features and mechanics](https://github.com
 
 ### Gradle
 
-Step 1. Add the JitPack repository to your build file
+Step 1. Add the JitPack repository to your build file:
 ```
 allprojects {
     repositories {
@@ -35,7 +38,7 @@ allprojects {
     }
 }
 ```
-Step 2. Add the dependency
+Step 2. Add the dependency:
 ```
 dependencies {
         implementation 'com.github.papsign:Ktor-OpenAPI-Generator:-SNAPSHOT'
@@ -114,7 +117,7 @@ data class StringResponse(val str: String)
 data class StringUsable(val str: String)
 ```
 
-Creates this openapi.json description:
+Creates this `openapi.json` description:
 
 ```json
 {  

--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ dependencies {
     
     implementation "io.ktor:ktor-jackson:$ktor_version" // needed for parameter parsing and multipart parsing
     implementation "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.9.8" // needed for multipart parsing
-    implementation 'org.webjars:swagger-ui:3.18.2'
+    implementation 'org.webjars:swagger-ui:3.25.0'
  
     implementation "org.reflections:reflections:0.9.11" // only used while initializing
     

--- a/src/main/kotlin/com/papsign/ktor/openapigen/OpenAPIGen.kt
+++ b/src/main/kotlin/com/papsign/ktor/openapigen/OpenAPIGen.kt
@@ -67,6 +67,7 @@ class OpenAPIGen(
 
         var swaggerUiPath = "swagger-ui"
         var serveSwaggerUi = true
+        var swaggerUiVersion = "3.25.0"
 
         var schemaNamer: (KType) -> String = KType::toString
 
@@ -118,7 +119,7 @@ class OpenAPIGen(
             val api = OpenAPI()
             val cfg = Configuration(api).apply(configure)
             if (cfg.serveSwaggerUi) {
-                val ui = SwaggerUi(cfg.swaggerUiPath)
+                val ui = SwaggerUi(cfg.swaggerUiPath, cfg.swaggerUiVersion)
                 pipeline.intercept(ApplicationCallPipeline.Call) {
                     val cmp = "/${cfg.swaggerUiPath.trim('/')}/"
                     if (call.request.path().startsWith(cmp))

--- a/src/main/kotlin/com/papsign/ktor/openapigen/SwaggerUI.kt
+++ b/src/main/kotlin/com/papsign/ktor/openapigen/SwaggerUI.kt
@@ -14,7 +14,7 @@ import io.ktor.request.port
 import io.ktor.response.respond
 import java.net.URL
 
-class SwaggerUi(val basePath: String) {
+class SwaggerUi(private val basePath: String, private val version: String) {
     private val notFound = mutableListOf<String>()
     private val content = mutableMapOf<String, ResourceContent>()
     suspend fun serve(filename: String?, call: ApplicationCall) {
@@ -22,7 +22,7 @@ class SwaggerUi(val basePath: String) {
             in notFound -> return
             null -> return
             else -> {
-                val resource = this::class.java.getResource("/META-INF/resources/webjars/swagger-ui/3.18.2/$filename")
+                val resource = this::class.java.getResource("/META-INF/resources/webjars/swagger-ui/$version/$filename")
                 if (resource == null) {
                     notFound.add(filename)
                     return


### PR DESCRIPTION
Making the version configurable means people can use a different version of `org.webjars:swagger-ui` with this library.