### PR TITLE
Add StringExample for easier examples of String properties

### DIFF
--- a/src/main/kotlin/com/papsign/ktor/openapigen/annotations/type/string/example/StringExample.kt
+++ b/src/main/kotlin/com/papsign/ktor/openapigen/annotations/type/string/example/StringExample.kt
@@ -1,0 +1,10 @@
+package com.papsign.ktor.openapigen.annotations.type.string.example
+
+import com.papsign.ktor.openapigen.schema.processor.SchemaProcessorAnnotation
+
+/**
+ * Provide examples for a String property
+ */
+@Target(AnnotationTarget.PROPERTY)
+@SchemaProcessorAnnotation(StringExampleProcessor::class)
+annotation class StringExample(vararg val examples: String)

--- a/src/main/kotlin/com/papsign/ktor/openapigen/annotations/type/string/example/StringExampleProcessor.kt
+++ b/src/main/kotlin/com/papsign/ktor/openapigen/annotations/type/string/example/StringExampleProcessor.kt
@@ -1,0 +1,23 @@
+package com.papsign.ktor.openapigen.annotations.type.string.example
+
+import com.papsign.ktor.openapigen.model.schema.SchemaModel
+import com.papsign.ktor.openapigen.schema.processor.SchemaProcessor
+import kotlin.reflect.KType
+
+object StringExampleProcessor: SchemaProcessor<StringExample> {
+    override fun process(model: SchemaModel<*>, type: KType, annotation: StringExample): SchemaModel<*> {
+        (model as SchemaModel<String?>).apply {
+            if (annotation.examples.size > 1) {
+                examples = examples?.plus(annotation.examples) ?: annotation.examples.asList()
+            } else {
+                if (example == null) {
+                    example = annotation.examples.getOrNull(0)
+                } else {
+                    examples = examples?.plus(annotation.examples)
+                }
+            }
+        }
+        return model
+    }
+
+}

--- a/src/test/kotlin/TestServer.kt
+++ b/src/test/kotlin/TestServer.kt
@@ -31,6 +31,7 @@ import com.papsign.ktor.openapigen.annotations.type.number.ConstraintVialoation
 import com.papsign.ktor.openapigen.annotations.type.number.integer.clamp.Clamp
 import com.papsign.ktor.openapigen.annotations.type.number.integer.max.Max
 import com.papsign.ktor.openapigen.annotations.type.number.integer.min.Min
+import com.papsign.ktor.openapigen.annotations.type.string.example.StringExample
 import io.ktor.application.application
 import io.ktor.application.call
 import io.ktor.application.install
@@ -227,7 +228,7 @@ object TestServer {
     data class NameParam(@HeaderParam("A simple Header Param") @OpenAPIName("X-NAME") val name: String)
 
     @Response("A Response for header param example")
-    data class NameGreetingResponse(val str: String)
+    data class NameGreetingResponse(@StringExample("Hi, John!") val str: String)
 
 
     @Response("A String Response")


### PR DESCRIPTION
This PR adds support for simple string examples on string properties.
This is currently possible via `@WithExample`, but that approach requires creating an `ExampleProvider` for each property that returns the example string. 

Sample code:
```kotlin
@Response("A Response for header param example")
data class NameGreetingResponse(
    @StringExample("Hello John") val str: String
)
```

Generated JSON:
```json
      "NameGreetingResponse" : {
        "nullable" : false,
        "properties" : {
          "str" : {
            "example" : "Hi, John!",
            "nullable" : false,
            "type" : "string"
          }
        },
        "required" : [ "str" ],
        "type" : "object"
      },
```

Swagger UI:
<img width="348" alt="Screen Shot 2020-05-21 at 1 40 54 PM" src="https://user-images.githubusercontent.com/3267925/82593839-b68fc180-9b68-11ea-988a-8aa7b99fbfd0.png">

