### PR TITLE
Preserve generic type info when parse body

### DIFF
--- a/src/main/kotlin/com/papsign/ktor/openapigen/content/type/BodyParser.kt
+++ b/src/main/kotlin/com/papsign/ktor/openapigen/content/type/BodyParser.kt
@@ -4,8 +4,9 @@ import io.ktor.application.ApplicationCall
 import io.ktor.http.ContentType
 import io.ktor.util.pipeline.PipelineContext
 import kotlin.reflect.KClass
+import kotlin.reflect.KType
 
 interface BodyParser: ContentTypeProvider {
     fun <T: Any> getParseableContentTypes(clazz: KClass<T>): List<ContentType>
-    suspend fun <T: Any> parseBody(clazz: KClass<T>, request: PipelineContext<Unit, ApplicationCall>): T
+    suspend fun <T: Any> parseBody(clazz: KType, request: PipelineContext<Unit, ApplicationCall>): T
 }

--- a/src/main/kotlin/com/papsign/ktor/openapigen/content/type/binary/BinaryContentTypeParser.kt
+++ b/src/main/kotlin/com/papsign/ktor/openapigen/content/type/binary/BinaryContentTypeParser.kt
@@ -50,8 +50,8 @@ object BinaryContentTypeParser: BodyParser, ResponseSerializer, OpenAPIGenModule
     }
 
     @Suppress("UNCHECKED_CAST")
-    override suspend fun <T : Any> parseBody(clazz: KClass<T>, request: PipelineContext<Unit, ApplicationCall>): T {
-        return clazz.getAcceptableConstructor().call( request.context.receiveStream())
+    override suspend fun <T : Any> parseBody(clazz: KType, request: PipelineContext<Unit, ApplicationCall>): T {
+        return (clazz.classifier as KClass<T>).getAcceptableConstructor().call( request.context.receiveStream())
     }
 
     override fun <T> getMediaType(type: KType, apiGen: OpenAPIGen, provider: ModuleProvider<*>, example: T?, usage: ContentTypeProvider.Usage): Map<ContentType, MediaTypeModel<T>>? {

--- a/src/main/kotlin/com/papsign/ktor/openapigen/content/type/ktor/KtorContentProvider.kt
+++ b/src/main/kotlin/com/papsign/ktor/openapigen/content/type/ktor/KtorContentProvider.kt
@@ -68,7 +68,7 @@ object KtorContentProvider : ContentTypeProvider, BodyParser, ResponseSerializer
         return contentTypes!!.toList()
     }
 
-    override suspend fun <T: Any> parseBody(clazz: KClass<T>, request: PipelineContext<Unit, ApplicationCall>): T {
+    override suspend fun <T: Any> parseBody(clazz: KType, request: PipelineContext<Unit, ApplicationCall>): T {
         return request.call.receive(clazz)
     }
 

--- a/src/main/kotlin/com/papsign/ktor/openapigen/content/type/multipart/MultipartFormDataContentProvider.kt
+++ b/src/main/kotlin/com/papsign/ktor/openapigen/content/type/multipart/MultipartFormDataContentProvider.kt
@@ -68,7 +68,7 @@ object MultipartFormDataContentProvider : BodyParser, OpenAPIGenModuleExtension 
     private val typeContentTypes = HashMap<KType, Map<String, MediaTypeEncodingModel>>()
 
 
-    override suspend fun <T : Any> parseBody(clazz: KClass<T>, request: PipelineContext<Unit, ApplicationCall>): T {
+    override suspend fun <T : Any> parseBody(clazz: KType, request: PipelineContext<Unit, ApplicationCall>): T {
         val objectMap = HashMap<String, Any>()
         request.context.receiveMultipart().forEachPart {
             val name = it.name
@@ -86,7 +86,7 @@ object MultipartFormDataContentProvider : BodyParser, OpenAPIGenModuleExtension 
                 }
             }
         }
-        val ctor = clazz.primaryConstructor!!
+        val ctor = (clazz.classifier as KClass<T>).primaryConstructor!!
         return ctor.callBy(ctor.parameters.associateWith {
             val raw = objectMap[it.openAPIName]
             if ((raw == null || (raw !is InputStream && streamTypes.contains(it.type))) && it.type.isMarkedNullable) {

--- a/src/main/kotlin/com/papsign/ktor/openapigen/route/OpenAPIRoute.kt
+++ b/src/main/kotlin/com/papsign/ktor/openapigen/route/OpenAPIRoute.kt
@@ -23,6 +23,7 @@ import io.ktor.routing.application
 import io.ktor.routing.contentType
 import io.ktor.util.pipeline.PipelineContext
 import kotlin.reflect.KClass
+import kotlin.reflect.typeOf
 
 abstract class OpenAPIRoute<T : OpenAPIRoute<T>>(val ktorRoute: Route, val provider: CachingModuleProvider) {
     private val log = classLogger()
@@ -58,7 +59,7 @@ abstract class OpenAPIRoute<T : OpenAPIRoute<T>>(val ktorRoute: Route, val provi
                         getContentTypesMap(B::class).forEach { (contentType, parsers) ->
                             contentType(contentType) {
                                 handle {
-                                    val receive: B = parsers.getBodyParser(call.request.contentType()).parseBody(B::class, this)
+                                    val receive: B = parsers.getBodyParser(call.request.contentType()).parseBody(typeOf<B>(), this)
                                     val params: P = if (Unit is P) Unit else parameterHandler.parse(call.parameters, call.request.headers)
                                     pass(this, responder, PHandler.handle(params), BHandler.handle(receive))
                                 }


### PR DESCRIPTION
Using KType and `typeOf<B>` instead of B::class to preserve generic type info, so being able to receive something like `List<T>` as a body