### PR TITLE
use slf4j api instead of direct logback dependency to avoid slf4j warnings about multiple bindings

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,21 +12,21 @@ repositories {
 
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
-    implementation "ch.qos.logback:logback-classic:$logback_version"
+    implementation "org.slf4j:slf4j-api:$slf4j_version"
     implementation "io.ktor:ktor-server-core:$ktor_version"
     implementation "io.ktor:ktor-server-host-common:$ktor_version"
     implementation "io.ktor:ktor-metrics:$ktor_version"
     implementation "io.ktor:ktor-server-sessions:$ktor_version"
-    
+
     implementation "io.ktor:ktor-jackson:$ktor_version" // needed for parameter parsing and multipart parsing
     implementation "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.9.8" // needed for multipart parsing
     implementation 'org.webjars:swagger-ui:3.25.0'
- 
+
     implementation "org.reflections:reflections:0.9.11" // only used while initializing
-    
+
     testImplementation "io.ktor:ktor-server-netty:$ktor_version"
     testImplementation "io.ktor:ktor-server-test-host:$ktor_version"
-    
+    testImplementation "ch.qos.logback:logback-classic:$logback_version"
 }
 
 compileKotlin {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,5 @@
 kotlin.code.style=official
 ktor_version=1.3.2
 logback_version=1.2.1
+slf4j_version=1.7.30
 kotlin_version=1.3.70


### PR DESCRIPTION
Currently logback is defined as implementation dependency, this leads to projects using this library and having a different implementation of slf4j generating a warning. This can easily be fixed by depending on the slf4j-api instead of logback directly. The code already uses the api only.

Example warning:
```
SLF4J: Class path contains multiple SLF4J bindings.
SLF4J: Found binding in [jar:file:/home/david/.gradle/caches/modules-2/files-2.1/org.apache.logging.log4j/log4j-slf4j-impl/2.12.1/14973e22497adaf0196d481fb99c5dc2a0b58d41/log4j-slf4j-impl-2.12.1.jar!/org/slf4j/impl/StaticLoggerBinder.class]
SLF4J: Found binding in [jar:file:/home/david/.gradle/caches/modules-2/files-2.1/ch.qos.logback/logback-classic/1.2.1/706a8b8206ead3683ec639dd270d11fd948fbb0e/logback-classic-1.2.1.jar!/org/slf4j/impl/StaticLoggerBinder.class]
SLF4J: See http://www.slf4j.org/codes.html#multiple_bindings for an explanation.
SLF4J: Actual binding is of type [org.apache.logging.slf4j.Log4jLoggerFactory]
```