### PR TITLE
Allow explicit class references when building routes

### DIFF
--- a/src/main/kotlin/com/papsign/ktor/openapigen/KTypeUtil.kt
+++ b/src/main/kotlin/com/papsign/ktor/openapigen/KTypeUtil.kt
@@ -1,27 +1,24 @@
 package com.papsign.ktor.openapigen
 
-import com.papsign.ktor.openapigen.annotations.mapping.openAPIName
-import java.lang.reflect.Field
 import kotlin.reflect.*
 import kotlin.reflect.full.createType
-import kotlin.reflect.full.declaredMemberProperties
 import kotlin.reflect.full.memberProperties
-import kotlin.reflect.jvm.javaField
 import kotlin.reflect.jvm.jvmErasure
 
 val unitKType = getKType<Unit>()
 
-inline fun <reified T> isNullable(): Boolean {
+internal inline fun <reified T> isNullable(): Boolean {
     return null is T
 }
 
-inline fun <reified T> getKType() = typeOf<T>()
+@PublishedApi
+internal inline fun <reified T> getKType() = typeOf<T>()
 
-fun KType.strip(nullable: Boolean = isMarkedNullable): KType {
+internal fun KType.strip(nullable: Boolean = isMarkedNullable): KType {
     return jvmErasure.createType(arguments, nullable)
 }
 
-fun KType.deepStrip(nullable: Boolean = isMarkedNullable): KType {
+internal fun KType.deepStrip(nullable: Boolean = isMarkedNullable): KType {
     return jvmErasure.createType(arguments.map { it.copy(type = it.type?.deepStrip()) }, nullable)
 }
 
@@ -44,4 +41,4 @@ val KType.memberProperties: List<KTypeProperty>
         }
     }
 
-val KClass<*>.isInterface get() = java.isInterface
+internal val KClass<*>.isInterface get() = java.isInterface

--- a/src/main/kotlin/com/papsign/ktor/openapigen/content/type/BodyParser.kt
+++ b/src/main/kotlin/com/papsign/ktor/openapigen/content/type/BodyParser.kt
@@ -3,10 +3,9 @@ package com.papsign.ktor.openapigen.content.type
 import io.ktor.application.ApplicationCall
 import io.ktor.http.ContentType
 import io.ktor.util.pipeline.PipelineContext
-import kotlin.reflect.KClass
 import kotlin.reflect.KType
 
 interface BodyParser: ContentTypeProvider {
-    fun <T: Any> getParseableContentTypes(clazz: KClass<T>): List<ContentType>
+    fun <T: Any> getParseableContentTypes(type: KType): List<ContentType>
     suspend fun <T: Any> parseBody(clazz: KType, request: PipelineContext<Unit, ApplicationCall>): T
 }

--- a/src/main/kotlin/com/papsign/ktor/openapigen/content/type/ResponseSerializer.kt
+++ b/src/main/kotlin/com/papsign/ktor/openapigen/content/type/ResponseSerializer.kt
@@ -4,13 +4,13 @@ import io.ktor.application.ApplicationCall
 import io.ktor.http.ContentType
 import io.ktor.http.HttpStatusCode
 import io.ktor.util.pipeline.PipelineContext
-import kotlin.reflect.KClass
+import kotlin.reflect.KType
 
 interface ResponseSerializer: ContentTypeProvider {
     /**
      * used to determine which registered response serializer is used, based on the accept header
      */
-    fun <T: Any> getSerializableContentTypes(clazz: KClass<T>): List<ContentType>
+    fun <T: Any> getSerializableContentTypes(type: KType): List<ContentType>
     suspend fun <T: Any> respond(response: T, request: PipelineContext<Unit, ApplicationCall>, contentType: ContentType)
     suspend fun <T: Any> respond(statusCode: HttpStatusCode, response: T, request: PipelineContext<Unit, ApplicationCall>, contentType: ContentType)
 }

--- a/src/main/kotlin/com/papsign/ktor/openapigen/content/type/binary/BinaryContentTypeParser.kt
+++ b/src/main/kotlin/com/papsign/ktor/openapigen/content/type/binary/BinaryContentTypeParser.kt
@@ -29,12 +29,12 @@ object BinaryContentTypeParser: BodyParser, ResponseSerializer, OpenAPIGenModule
         return constructors.first { it.parameters.size == 1 && acceptedTypes.contains(it.parameters[0].type) }
     }
 
-    override fun <T : Any> getParseableContentTypes(clazz: KClass<T>): List<ContentType> {
-        return clazz.findAnnotation<BinaryRequest>()?.contentTypes?.map(ContentType.Companion::parse) ?: listOf()
+    override fun <T : Any> getParseableContentTypes(type: KType): List<ContentType> {
+        return type.jvmErasure.findAnnotation<BinaryRequest>()?.contentTypes?.map(ContentType.Companion::parse) ?: listOf()
     }
 
-    override fun <T: Any> getSerializableContentTypes(clazz: KClass<T>):  List<ContentType> {
-        return clazz.findAnnotation<BinaryResponse>()?.contentTypes?.map(ContentType.Companion::parse) ?: listOf()
+    override fun <T: Any> getSerializableContentTypes(type: KType):  List<ContentType> {
+        return type.jvmErasure.findAnnotation<BinaryResponse>()?.contentTypes?.map(ContentType.Companion::parse) ?: listOf()
     }
 
     override suspend fun <T : Any> respond(response: T, request: PipelineContext<Unit, ApplicationCall>, contentType: ContentType) {

--- a/src/main/kotlin/com/papsign/ktor/openapigen/content/type/ktor/KtorContentProvider.kt
+++ b/src/main/kotlin/com/papsign/ktor/openapigen/content/type/ktor/KtorContentProvider.kt
@@ -22,7 +22,6 @@ import io.ktor.http.HttpStatusCode
 import io.ktor.request.receive
 import io.ktor.response.respond
 import io.ktor.util.pipeline.PipelineContext
-import kotlin.reflect.KClass
 import kotlin.reflect.KType
 import kotlin.reflect.full.findAnnotation
 import kotlin.reflect.jvm.jvmErasure
@@ -63,7 +62,7 @@ object KtorContentProvider : ContentTypeProvider, BodyParser, ResponseSerializer
         return contentTypes.associateWith { media.copy() }
     }
 
-    override fun <T : Any> getParseableContentTypes(clazz: KClass<T>): List<ContentType> {
+    override fun <T : Any> getParseableContentTypes(type: KType): List<ContentType> {
         return contentTypes!!.toList()
     }
 
@@ -71,7 +70,7 @@ object KtorContentProvider : ContentTypeProvider, BodyParser, ResponseSerializer
         return request.call.receive(clazz)
     }
 
-    override fun <T: Any> getSerializableContentTypes(clazz: KClass<T>): List<ContentType> {
+    override fun <T: Any> getSerializableContentTypes(type: KType): List<ContentType> {
         return contentTypes!!.toList()
     }
 

--- a/src/main/kotlin/com/papsign/ktor/openapigen/content/type/multipart/MultipartFormDataContentProvider.kt
+++ b/src/main/kotlin/com/papsign/ktor/openapigen/content/type/multipart/MultipartFormDataContentProvider.kt
@@ -31,7 +31,7 @@ import kotlin.reflect.jvm.jvmErasure
 
 object MultipartFormDataContentProvider : BodyParser, OpenAPIGenModuleExtension {
 
-    override fun <T : Any> getParseableContentTypes(clazz: KClass<T>): List<ContentType> {
+    override fun <T : Any> getParseableContentTypes(type: KType): List<ContentType> {
         return listOf(ContentType.MultiPart.FormData)
     }
 
@@ -68,7 +68,7 @@ object MultipartFormDataContentProvider : BodyParser, OpenAPIGenModuleExtension 
     private val typeContentTypes = HashMap<KType, Map<String, MediaTypeEncodingModel>>()
 
 
-    override suspend fun <T : Any> parseBody(clazz: KType, request: PipelineContext<Unit, ApplicationCall>): T {
+    override suspend fun <T : Any> parseBody(type: KType, request: PipelineContext<Unit, ApplicationCall>): T {
         val objectMap = HashMap<String, Any>()
         request.context.receiveMultipart().forEachPart {
             val name = it.name
@@ -86,7 +86,8 @@ object MultipartFormDataContentProvider : BodyParser, OpenAPIGenModuleExtension 
                 }
             }
         }
-        val ctor = (clazz.classifier as KClass<T>).primaryConstructor!!
+        @Suppress("UNCHECKED_CAST")
+        val ctor = (type.classifier as KClass<T>).primaryConstructor!!
         return ctor.callBy(ctor.parameters.associateWith {
             val raw = objectMap[it.openAPIName]
             if ((raw == null || (raw !is InputStream && streamTypes.contains(it.type))) && it.type.isMarkedNullable) {

--- a/src/main/kotlin/com/papsign/ktor/openapigen/modules/handlers/RequestHandlerModule.kt
+++ b/src/main/kotlin/com/papsign/ktor/openapigen/modules/handlers/RequestHandlerModule.kt
@@ -17,6 +17,7 @@ import com.papsign.ktor.openapigen.modules.registerModule
 import kotlin.reflect.KClass
 import kotlin.reflect.KType
 import kotlin.reflect.full.findAnnotation
+import kotlin.reflect.full.starProjectedType
 
 class RequestHandlerModule<T : Any>(
         val requestClass: KClass<T>,
@@ -51,7 +52,7 @@ class RequestHandlerModule<T : Any>(
     }
 
     companion object {
-        inline fun <reified T : Any> create(requestExample: T? = null) = RequestHandlerModule(T::class,
-            getKType<T>(), requestExample)
+        inline fun <reified T : Any> create(requestExample: T? = null) = RequestHandlerModule(T::class, getKType<T>(), requestExample)
+        fun <T : Any> create(tClass: KClass<T>, requestExample: T? = null) = RequestHandlerModule(tClass, tClass.starProjectedType, requestExample)
     }
 }

--- a/src/main/kotlin/com/papsign/ktor/openapigen/modules/handlers/RequestHandlerModule.kt
+++ b/src/main/kotlin/com/papsign/ktor/openapigen/modules/handlers/RequestHandlerModule.kt
@@ -1,6 +1,5 @@
 package com.papsign.ktor.openapigen.modules.handlers
 
-import com.papsign.ktor.openapigen.getKType
 import com.papsign.ktor.openapigen.OpenAPIGen
 import com.papsign.ktor.openapigen.annotations.Request
 import com.papsign.ktor.openapigen.classLogger
@@ -14,13 +13,11 @@ import com.papsign.ktor.openapigen.modules.ofType
 import com.papsign.ktor.openapigen.modules.openapi.OperationModule
 import com.papsign.ktor.openapigen.modules.providers.ParameterProvider
 import com.papsign.ktor.openapigen.modules.registerModule
-import kotlin.reflect.KClass
 import kotlin.reflect.KType
 import kotlin.reflect.full.findAnnotation
-import kotlin.reflect.full.starProjectedType
+import kotlin.reflect.jvm.jvmErasure
 
 class RequestHandlerModule<T : Any>(
-        val requestClass: KClass<T>,
         val requestType: KType,
         val requestExample: T? = null
 ) : OperationModule {
@@ -35,7 +32,7 @@ class RequestHandlerModule<T : Any>(
             mediaType.map { Pair(it.key.toString(), it.value) }
         }.flatten().associate { it }
 
-        val requestMeta = requestClass.findAnnotation<Request>()
+        val requestMeta = requestType.jvmErasure.findAnnotation<Request>()
 
         val parameters = provider.ofType<ParameterProvider>().flatMap { it.getParameters(apiGen, provider) }
         operation.parameters = operation.parameters?.let { (it + parameters).distinct() } ?: parameters
@@ -52,7 +49,6 @@ class RequestHandlerModule<T : Any>(
     }
 
     companion object {
-        inline fun <reified T : Any> create(requestExample: T? = null) = RequestHandlerModule(T::class, getKType<T>(), requestExample)
-        fun <T : Any> create(tClass: KClass<T>, requestExample: T? = null) = RequestHandlerModule(tClass, tClass.starProjectedType, requestExample)
+        fun <T : Any> create(tType: KType, requestExample: T? = null) = RequestHandlerModule(tType, requestExample)
     }
 }

--- a/src/main/kotlin/com/papsign/ktor/openapigen/modules/handlers/ResponseHandlerModule.kt
+++ b/src/main/kotlin/com/papsign/ktor/openapigen/modules/handlers/ResponseHandlerModule.kt
@@ -16,8 +16,10 @@ import com.papsign.ktor.openapigen.modules.providers.StatusProvider
 import com.papsign.ktor.openapigen.modules.registerModule
 import io.ktor.http.HttpStatusCode
 import kotlin.reflect.KAnnotatedElement
+import kotlin.reflect.KClass
 import kotlin.reflect.KType
 import kotlin.reflect.full.findAnnotation
+import kotlin.reflect.full.starProjectedType
 
 class ResponseHandlerModule<T>(val responseType: KType, val responseExample: T? = null) : OperationModule {
     private val log = classLogger()
@@ -47,5 +49,6 @@ class ResponseHandlerModule<T>(val responseType: KType, val responseExample: T? 
 
     companion object {
         inline fun <reified T : Any> create(responseExample: T? = null) = ResponseHandlerModule(getKType<T>(), responseExample)
+        fun <T : Any> create(tClass: KClass<T>, responseExample: T? = null) = ResponseHandlerModule(tClass.starProjectedType, responseExample)
     }
 }

--- a/src/main/kotlin/com/papsign/ktor/openapigen/modules/handlers/ResponseHandlerModule.kt
+++ b/src/main/kotlin/com/papsign/ktor/openapigen/modules/handlers/ResponseHandlerModule.kt
@@ -1,6 +1,5 @@
 package com.papsign.ktor.openapigen.modules.handlers
 
-import com.papsign.ktor.openapigen.getKType
 import com.papsign.ktor.openapigen.OpenAPIGen
 import com.papsign.ktor.openapigen.annotations.Response
 import com.papsign.ktor.openapigen.classLogger
@@ -16,10 +15,8 @@ import com.papsign.ktor.openapigen.modules.providers.StatusProvider
 import com.papsign.ktor.openapigen.modules.registerModule
 import io.ktor.http.HttpStatusCode
 import kotlin.reflect.KAnnotatedElement
-import kotlin.reflect.KClass
 import kotlin.reflect.KType
 import kotlin.reflect.full.findAnnotation
-import kotlin.reflect.full.starProjectedType
 
 class ResponseHandlerModule<T>(val responseType: KType, val responseExample: T? = null) : OperationModule {
     private val log = classLogger()
@@ -48,7 +45,6 @@ class ResponseHandlerModule<T>(val responseType: KType, val responseExample: T? 
     }
 
     companion object {
-        inline fun <reified T : Any> create(responseExample: T? = null) = ResponseHandlerModule(getKType<T>(), responseExample)
-        fun <T : Any> create(tClass: KClass<T>, responseExample: T? = null) = ResponseHandlerModule(tClass.starProjectedType, responseExample)
+        fun <T : Any> create(tType: KType, responseExample: T? = null) = ResponseHandlerModule(tType, responseExample)
     }
 }

--- a/src/main/kotlin/com/papsign/ktor/openapigen/modules/handlers/ThrowOperationHandler.kt
+++ b/src/main/kotlin/com/papsign/ktor/openapigen/modules/handlers/ThrowOperationHandler.kt
@@ -21,8 +21,11 @@ object ThrowOperationHandler : OperationModule {
     private val log = classLogger()
     override fun configure(apiGen: OpenAPIGen, provider: ModuleProvider<*>, operation: OperationModel) {
 
-        val exceptions = provider.ofType<ThrowInfoProvider>().flatMap { it.exceptions }
-        exceptions.groupBy { it.status }.forEach { exceptions ->
+        provider
+            .ofType<ThrowInfoProvider>()
+            .flatMap { it.exceptions }
+            .groupBy { it.status }
+            .forEach { exceptions ->
             val map: MutableMap<String, MediaTypeModel<*>> = exceptions.value.flatMap { ex ->
                 provider.ofType<ResponseSerializer>().mapNotNull {
                     if (ex.contentType == unitKType) return@mapNotNull null

--- a/src/main/kotlin/com/papsign/ktor/openapigen/parameters/util/Util.kt
+++ b/src/main/kotlin/com/papsign/ktor/openapigen/parameters/util/Util.kt
@@ -7,14 +7,17 @@ import com.papsign.ktor.openapigen.parameters.handlers.ModularParameterHandler
 import com.papsign.ktor.openapigen.parameters.handlers.ParameterHandler
 import com.papsign.ktor.openapigen.parameters.handlers.UnitParameterHandler
 import com.papsign.ktor.openapigen.parameters.parsers.builders.Builder
-import kotlin.reflect.KClass
+import kotlin.reflect.KFunction
 import kotlin.reflect.KParameter
+import kotlin.reflect.KType
 import kotlin.reflect.full.findAnnotation
 import kotlin.reflect.full.primaryConstructor
+import kotlin.reflect.jvm.jvmErasure
 
-
-inline fun <T : Any> buildParameterHandler(tClass: KClass<T>): ParameterHandler<T> {
-    if (tClass == Unit::class) return UnitParameterHandler as ParameterHandler<T>
+fun <T : Any> buildParameterHandler(tType: KType): ParameterHandler<T> {
+    @Suppress("UNCHECKED_CAST")
+    if (tType.classifier == Unit::class) return UnitParameterHandler as ParameterHandler<T>
+    val tClass = tType.jvmErasure
     assert(tClass.isData) { "API route with ${tClass.simpleName} must be a data class." }
     val constructor = tClass.primaryConstructor ?: error("API routes with ${tClass.simpleName} must have a primary constructor.")
     val parsers: Map<KParameter, Builder<*>> = constructor.parameters.associateWith { param ->
@@ -24,8 +27,9 @@ inline fun <T : Any> buildParameterHandler(tClass: KClass<T>): ParameterHandler<
         param.findAnnotation<QueryParam>()?.let { a -> a.style.factory.buildBuilderForced(type, a.explode) } ?:
         error("Parameters must be annotated with @PathParam or @QueryParam")
     }
+    @Suppress("UNCHECKED_CAST")
     return ModularParameterHandler(
         parsers,
-        constructor
+        constructor as KFunction<T>
     )
 }

--- a/src/main/kotlin/com/papsign/ktor/openapigen/parameters/util/Util.kt
+++ b/src/main/kotlin/com/papsign/ktor/openapigen/parameters/util/Util.kt
@@ -7,16 +7,16 @@ import com.papsign.ktor.openapigen.parameters.handlers.ModularParameterHandler
 import com.papsign.ktor.openapigen.parameters.handlers.ParameterHandler
 import com.papsign.ktor.openapigen.parameters.handlers.UnitParameterHandler
 import com.papsign.ktor.openapigen.parameters.parsers.builders.Builder
+import kotlin.reflect.KClass
 import kotlin.reflect.KParameter
 import kotlin.reflect.full.findAnnotation
 import kotlin.reflect.full.primaryConstructor
 
 
-inline fun <reified T : Any> buildParameterHandler(): ParameterHandler<T> {
-    if (Unit is T) return UnitParameterHandler as ParameterHandler<T>
-    val t = T::class
-    assert(t.isData) { "API route with ${t.simpleName} must be a data class." }
-    val constructor = t.primaryConstructor ?: error("API routes with ${t.simpleName} must have a primary constructor.")
+inline fun <T : Any> buildParameterHandler(tClass: KClass<T>): ParameterHandler<T> {
+    if (tClass == Unit::class) return UnitParameterHandler as ParameterHandler<T>
+    assert(tClass.isData) { "API route with ${tClass.simpleName} must be a data class." }
+    val constructor = tClass.primaryConstructor ?: error("API routes with ${tClass.simpleName} must have a primary constructor.")
     val parsers: Map<KParameter, Builder<*>> = constructor.parameters.associateWith { param ->
         val type = param.type
         param.findAnnotation<HeaderParam>()?.let { a -> a.style.factory.buildBuilderForced(type, a.explode) } ?:

--- a/src/main/kotlin/com/papsign/ktor/openapigen/route/OpenAPIRoute.kt
+++ b/src/main/kotlin/com/papsign/ktor/openapigen/route/OpenAPIRoute.kt
@@ -23,22 +23,20 @@ import io.ktor.routing.accept
 import io.ktor.routing.application
 import io.ktor.routing.contentType
 import io.ktor.util.pipeline.PipelineContext
-import kotlin.reflect.KClass
-import kotlin.reflect.full.starProjectedType
-import kotlin.reflect.typeOf
+import kotlin.reflect.KType
 
 abstract class OpenAPIRoute<T : OpenAPIRoute<T>>(val ktorRoute: Route, val provider: CachingModuleProvider) {
     private val log = classLogger()
 
     abstract fun child(route: Route = this.ktorRoute): T
 
-    inline fun <P : Any, R : Any, B : Any> handle(
-            paramsClass: KClass<P>,
-            responseClass: KClass<R>,
-            bodyClass: KClass<B>,
-            crossinline pass: suspend OpenAPIRoute<*>.(pipeline: PipelineContext<Unit, ApplicationCall>, responder: Responder, P, B) -> Unit
+    fun <P : Any, R : Any, B : Any> handle(
+        paramsType: KType,
+        responseType: KType,
+        bodyType: KType,
+        pass: suspend OpenAPIRoute<*>.(pipeline: PipelineContext<Unit, ApplicationCall>, responder: Responder, P, B) -> Unit
     ) {
-        val parameterHandler = buildParameterHandler<P>(paramsClass)
+        val parameterHandler = buildParameterHandler<P>(paramsType)
         provider.registerModule(parameterHandler)
 
         val apiGen = ktorRoute.application.openAPIGen
@@ -46,29 +44,29 @@ abstract class OpenAPIRoute<T : OpenAPIRoute<T>>(val ktorRoute: Route, val provi
             it.configure(apiGen, provider)
         }
 
-        val BHandler = ValidationHandler.build(bodyClass)
-        val PHandler = ValidationHandler.build(paramsClass)
+        val BHandler = ValidationHandler.build(bodyType)
+        val PHandler = ValidationHandler.build(paramsType)
 
         ktorRoute.apply {
-            getAcceptMap(responseClass).let {
+            getAcceptMap<R>(responseType).let {
                 if (it.isNotEmpty()) it else listOf(ContentType.Any to listOf(SelectedSerializer(KtorContentProvider)))
             }.forEach { (acceptType, serializers) ->
                 val responder = ContentTypeResponder(serializers.getResponseSerializer(acceptType), acceptType)
                 accept(acceptType) {
-                    if (bodyClass == Unit::class) {
+                    if (bodyType.classifier == Unit::class) {
                         handle {
                             @Suppress("UNCHECKED_CAST")
-                            val params: P = if (paramsClass == Unit::class) Unit as P else parameterHandler.parse(call.parameters, call.request.headers)
+                            val params: P = if (paramsType.classifier == Unit::class) Unit as P else parameterHandler.parse(call.parameters, call.request.headers)
                             @Suppress("UNCHECKED_CAST")
                             pass(this, responder, PHandler.handle(params), Unit as B)
                         }
                     } else {
-                        getContentTypesMap(bodyClass).forEach { (contentType, parsers) ->
+                        getContentTypesMap<B>(bodyType).forEach { (contentType, parsers) ->
                             contentType(contentType) {
                                 handle {
-                                    val receive: B = parsers.getBodyParser(call.request.contentType()).parseBody(bodyClass.starProjectedType, this)
+                                    val receive: B = parsers.getBodyParser(call.request.contentType()).parseBody(bodyType, this)
                                     @Suppress("UNCHECKED_CAST")
-                                    val params: P = if (paramsClass == Unit::class) Unit as P else parameterHandler.parse(call.parameters, call.request.headers)
+                                    val params: P = if (paramsType.classifier == Unit::class) Unit as P else parameterHandler.parse(call.parameters, call.request.headers)
                                     pass(this, responder, PHandler.handle(params), BHandler.handle(receive))
                                 }
                             }
@@ -89,9 +87,9 @@ abstract class OpenAPIRoute<T : OpenAPIRoute<T>>(val ktorRoute: Route, val provi
         return firstOrNull()?.module ?: throw OpenAPINoParserException(contentType)
     }
 
-    fun <B : Any> getContentTypesMap(clazz: KClass<B>) = mapContentTypes<SelectedParser> { module.getParseableContentTypes(clazz) }
+    fun <B : Any> getContentTypesMap(type: KType) = mapContentTypes<SelectedParser> { module.getParseableContentTypes<B>(type) }
 
-    fun <R : Any> getAcceptMap(clazz: KClass<R>) = mapContentTypes<SelectedSerializer> { module.getSerializableContentTypes(clazz) }
+    fun <R : Any> getAcceptMap(type: KType) = mapContentTypes<SelectedSerializer> { module.getSerializableContentTypes<R>(type) }
 
     inline fun <reified T : OpenAPIModule> mapContentTypes(noinline fn: T.() -> List<ContentType>): List<Pair<ContentType, List<T>>> {
         return provider.ofType<T>().flatMap { parser ->

--- a/src/main/kotlin/com/papsign/ktor/openapigen/route/OpenAPIRoute.kt
+++ b/src/main/kotlin/com/papsign/ktor/openapigen/route/OpenAPIRoute.kt
@@ -63,7 +63,6 @@ abstract class OpenAPIRoute<T : OpenAPIRoute<T>>(val ktorRoute: Route, val provi
                             pass(this, responder, PHandler.handle(params), Unit as B)
                         }
                     } else {
-                        if(paramsClass == Unit::class)
                         getContentTypesMap(bodyClass).forEach { (contentType, parsers) ->
                             contentType(contentType) {
                                 handle {

--- a/src/main/kotlin/com/papsign/ktor/openapigen/route/path/auth/Functions.kt
+++ b/src/main/kotlin/com/papsign/ktor/openapigen/route/path/auth/Functions.kt
@@ -6,14 +6,14 @@ import com.papsign.ktor.openapigen.route.preHandle
 import com.papsign.ktor.openapigen.route.response.OpenAPIPipelineAuthContext
 import io.ktor.http.HttpMethod
 import io.ktor.util.pipeline.ContextDsl
-import kotlin.reflect.KClass
 import kotlin.reflect.full.starProjectedType
+import kotlin.reflect.typeOf
 
 @ContextDsl
 inline fun <reified P : Any, reified R : Any, A> OpenAPIAuthenticatedRoute<A>.get(
     vararg modules: RouteOpenAPIModule,
     example: R? = null,
-    crossinline body: suspend OpenAPIPipelineAuthContext<A, R>.(P) -> Unit
+    noinline body: suspend OpenAPIPipelineAuthContext<A, R>.(P) -> Unit
 ) = route(HttpMethod.Get, modules, example, body)
 
 @ContextDsl
@@ -21,7 +21,7 @@ inline fun <reified P : Any, reified R : Any, reified B : Any, A> OpenAPIAuthent
     vararg modules: RouteOpenAPIModule,
     exampleResponse: R? = null,
     exampleRequest: B? = null,
-    crossinline body: suspend OpenAPIPipelineAuthContext<A, R>.(P, B) -> Unit
+    noinline body: suspend OpenAPIPipelineAuthContext<A, R>.(P, B) -> Unit
 ) = route(HttpMethod.Post, modules, exampleResponse, exampleRequest, body)
 
 @ContextDsl
@@ -29,7 +29,7 @@ inline fun <reified P : Any, reified R : Any, reified B : Any, A> OpenAPIAuthent
     vararg modules: RouteOpenAPIModule,
     exampleResponse: R? = null,
     exampleRequest: B? = null,
-    crossinline body: suspend OpenAPIPipelineAuthContext<A, R>.(P, B) -> Unit
+    noinline body: suspend OpenAPIPipelineAuthContext<A, R>.(P, B) -> Unit
 ) = route(HttpMethod.Put, modules, exampleResponse, exampleRequest, body)
 
 @ContextDsl
@@ -37,21 +37,21 @@ inline fun <reified P : Any, reified R : Any, reified B : Any, A> OpenAPIAuthent
     vararg modules: RouteOpenAPIModule,
     exampleResponse: R? = null,
     exampleRequest: B? = null,
-    crossinline body: suspend OpenAPIPipelineAuthContext<A, R>.(P, B) -> Unit
+    noinline body: suspend OpenAPIPipelineAuthContext<A, R>.(P, B) -> Unit
 ) = route(HttpMethod.Patch, modules, exampleResponse, exampleRequest, body)
 
 @ContextDsl
 inline fun <reified P : Any, reified R : Any, A> OpenAPIAuthenticatedRoute<A>.delete(
     vararg modules: RouteOpenAPIModule,
     example: R? = null,
-    crossinline body: suspend OpenAPIPipelineAuthContext<A, R>.(P) -> Unit
+    noinline body: suspend OpenAPIPipelineAuthContext<A, R>.(P) -> Unit
 ) = route(HttpMethod.Delete, modules, example, body)
 
 @ContextDsl
 inline fun <reified P : Any, reified R : Any, A> OpenAPIAuthenticatedRoute<A>.head(
     vararg modules: RouteOpenAPIModule,
     example: R? = null,
-    crossinline body: suspend OpenAPIPipelineAuthContext<A, R>.(P) -> Unit
+    noinline body: suspend OpenAPIPipelineAuthContext<A, R>.(P) -> Unit
 ) = route(HttpMethod.Head, modules, example, body)
 
 @ContextDsl
@@ -60,9 +60,10 @@ inline fun <reified P : Any, reified R : Any, reified B : Any, A> OpenAPIAuthent
     modules: Array<out RouteOpenAPIModule>,
     exampleResponse: R? = null,
     exampleRequest: B? = null,
-    crossinline body: suspend OpenAPIPipelineAuthContext<A, R>.(P, B) -> Unit
+    noinline body: suspend OpenAPIPipelineAuthContext<A, R>.(P, B) -> Unit
 ) {
-    method(method).apply { modules.forEach { provider.registerModule(it, it::class.starProjectedType) } }.handle(exampleResponse, exampleRequest, body)
+    method(method).apply { modules.forEach { provider.registerModule(it, it::class.starProjectedType) } }
+        .handle(exampleResponse, exampleRequest, body)
 }
 
 @ContextDsl
@@ -70,41 +71,30 @@ inline fun <reified P : Any, reified R : Any, A> OpenAPIAuthenticatedRoute<A>.ro
     method: HttpMethod,
     modules: Array<out RouteOpenAPIModule>,
     exampleResponse: R? = null,
-    crossinline body: suspend OpenAPIPipelineAuthContext<A, R>.(P) -> Unit
+    noinline body: suspend OpenAPIPipelineAuthContext<A, R>.(P) -> Unit
 ) {
-    method(method).apply { modules.forEach { provider.registerModule(it, it::class.starProjectedType) } }.handle(exampleResponse, body)
+    method(method).apply { modules.forEach { provider.registerModule(it, it::class.starProjectedType) } }
+        .handle(exampleResponse, body)
 }
 
 @ContextDsl
 inline fun <reified P : Any, reified R : Any, reified B : Any, A> OpenAPIAuthenticatedRoute<A>.handle(
     exampleResponse: R? = null,
     exampleRequest: B? = null,
-    crossinline body: suspend OpenAPIPipelineAuthContext<A, R>.(P, B) -> Unit
+    noinline body: suspend OpenAPIPipelineAuthContext<A, R>.(P, B) -> Unit
 ) {
     preHandle<P, R, B, OpenAPIAuthenticatedRoute<A>>(exampleResponse, exampleRequest) {
-        handle(P::class, R::class, B::class, body)
+        handle(typeOf<P>(), typeOf<R>(), typeOf<B>(), body)
     }
 }
 
 @ContextDsl
 inline fun <reified P : Any, reified R : Any, A> OpenAPIAuthenticatedRoute<A>.handle(
     exampleResponse: R? = null,
-    crossinline body: suspend OpenAPIPipelineAuthContext<A, R>.(P) -> Unit
+    noinline body: suspend OpenAPIPipelineAuthContext<A, R>.(P) -> Unit
 ) {
     preHandle<P, R, Unit, OpenAPIAuthenticatedRoute<A>>(exampleResponse, Unit) {
-        handle(P::class, R::class, body)
-    }
-}
-
-@ContextDsl
-inline fun <P : Any, R : Any, A> OpenAPIAuthenticatedRoute<A>.handle(
-    pClass: KClass<P>,
-    rClass: KClass<R>,
-    exampleResponse: R? = null,
-    crossinline body: suspend OpenAPIPipelineAuthContext<A, R>.(P) -> Unit
-) {
-    preHandle<P, R, Unit, OpenAPIAuthenticatedRoute<A>>(pClass, rClass, Unit::class, exampleResponse, Unit) {
-        handle(pClass, rClass, body)
+        handle(typeOf<P>(), typeOf<R>(), body)
     }
 }
 

--- a/src/main/kotlin/com/papsign/ktor/openapigen/route/path/auth/Functions.kt
+++ b/src/main/kotlin/com/papsign/ktor/openapigen/route/path/auth/Functions.kt
@@ -6,6 +6,7 @@ import com.papsign.ktor.openapigen.route.preHandle
 import com.papsign.ktor.openapigen.route.response.OpenAPIPipelineAuthContext
 import io.ktor.http.HttpMethod
 import io.ktor.util.pipeline.ContextDsl
+import kotlin.reflect.KClass
 import kotlin.reflect.full.starProjectedType
 
 @ContextDsl
@@ -81,17 +82,29 @@ inline fun <reified P : Any, reified R : Any, reified B : Any, A> OpenAPIAuthent
     crossinline body: suspend OpenAPIPipelineAuthContext<A, R>.(P, B) -> Unit
 ) {
     preHandle<P, R, B, OpenAPIAuthenticatedRoute<A>>(exampleResponse, exampleRequest) {
-        handle(body)
+        handle(P::class, R::class, B::class, body)
     }
 }
 
 @ContextDsl
-inline fun <reified P : Any, reified R : Any,  A> OpenAPIAuthenticatedRoute<A>.handle(
+inline fun <reified P : Any, reified R : Any, A> OpenAPIAuthenticatedRoute<A>.handle(
     exampleResponse: R? = null,
     crossinline body: suspend OpenAPIPipelineAuthContext<A, R>.(P) -> Unit
 ) {
     preHandle<P, R, Unit, OpenAPIAuthenticatedRoute<A>>(exampleResponse, Unit) {
-        handle(body)
+        handle(P::class, R::class, body)
+    }
+}
+
+@ContextDsl
+inline fun <P : Any, R : Any, A> OpenAPIAuthenticatedRoute<A>.handle(
+    pClass: KClass<P>,
+    rClass: KClass<R>,
+    exampleResponse: R? = null,
+    crossinline body: suspend OpenAPIPipelineAuthContext<A, R>.(P) -> Unit
+) {
+    preHandle<P, R, Unit, OpenAPIAuthenticatedRoute<A>>(pClass, rClass, Unit::class, exampleResponse, Unit) {
+        handle(pClass, rClass, body)
     }
 }
 

--- a/src/main/kotlin/com/papsign/ktor/openapigen/route/path/auth/OpenAPIAuthenticatedRoute.kt
+++ b/src/main/kotlin/com/papsign/ktor/openapigen/route/path/auth/OpenAPIAuthenticatedRoute.kt
@@ -7,26 +7,40 @@ import com.papsign.ktor.openapigen.route.OpenAPIRoute
 import com.papsign.ktor.openapigen.route.response.AuthResponseContextImpl
 import com.papsign.ktor.openapigen.route.response.OpenAPIPipelineAuthContext
 import io.ktor.routing.Route
+import kotlin.reflect.KClass
 
-class OpenAPIAuthenticatedRoute<A>(route: Route, provider: CachingModuleProvider = CachingModuleProvider(), val authProvider: AuthProvider<A>): OpenAPIRoute<OpenAPIAuthenticatedRoute<A>>(route, provider) {
+class OpenAPIAuthenticatedRoute<A>(
+    route: Route,
+    provider: CachingModuleProvider = CachingModuleProvider(),
+    val authProvider: AuthProvider<A>
+) : OpenAPIRoute<OpenAPIAuthenticatedRoute<A>>(route, provider) {
 
     override fun child(route: Route): OpenAPIAuthenticatedRoute<A> {
         return OpenAPIAuthenticatedRoute(route, provider.child(), authProvider)
     }
 
-    inline fun <reified P : Any, reified R: Any, reified B : Any> handle(crossinline body: suspend OpenAPIPipelineAuthContext<A, R>.(P, B) -> Unit) {
+    inline fun <P : Any, R : Any, B : Any> handle(
+        pClass: KClass<P>,
+        rClass: KClass<R>,
+        bClass: KClass<B>,
+        crossinline body: suspend OpenAPIPipelineAuthContext<A, R>.(P, B) -> Unit
+    ) {
         child().apply {// child in case path is branch to prevent propagation of the mutable nature of the provider
             provider.registerModule(authProvider)
-            handle<P, R, B> { pipeline, responder, p, b ->
+            handle<P, R, B>(pClass, rClass, bClass) { pipeline, responder, p, b ->
                 AuthResponseContextImpl<A, R>(pipeline, authProvider, this, responder).body(p, b)
             }
         }
     }
 
-    inline fun <reified P : Any, reified R: Any> handle(crossinline body: suspend OpenAPIPipelineAuthContext<A, R>.(P) -> Unit) {
+    inline fun <P : Any, R : Any> handle(
+        pClass: KClass<P>,
+        rClass: KClass<R>,
+        crossinline body: suspend OpenAPIPipelineAuthContext<A, R>.(P) -> Unit
+    ) {
         child().apply {// child in case path is branch to prevent propagation of the mutable nature of the provider
             provider.registerModule(authProvider)
-            handle<P, R, Unit> { pipeline, responder, p: P, _ ->
+            handle<P, R, Unit>(pClass, rClass, Unit::class) { pipeline, responder, p: P, _ ->
                 AuthResponseContextImpl<A, R>(pipeline, authProvider, this, responder).body(p)
             }
         }

--- a/src/main/kotlin/com/papsign/ktor/openapigen/route/path/auth/OpenAPIAuthenticatedRoute.kt
+++ b/src/main/kotlin/com/papsign/ktor/openapigen/route/path/auth/OpenAPIAuthenticatedRoute.kt
@@ -7,7 +7,8 @@ import com.papsign.ktor.openapigen.route.OpenAPIRoute
 import com.papsign.ktor.openapigen.route.response.AuthResponseContextImpl
 import com.papsign.ktor.openapigen.route.response.OpenAPIPipelineAuthContext
 import io.ktor.routing.Route
-import kotlin.reflect.KClass
+import kotlin.reflect.KType
+import kotlin.reflect.typeOf
 
 class OpenAPIAuthenticatedRoute<A>(
     route: Route,
@@ -19,28 +20,38 @@ class OpenAPIAuthenticatedRoute<A>(
         return OpenAPIAuthenticatedRoute(route, provider.child(), authProvider)
     }
 
-    inline fun <P : Any, R : Any, B : Any> handle(
-        pClass: KClass<P>,
-        rClass: KClass<R>,
-        bClass: KClass<B>,
-        crossinline body: suspend OpenAPIPipelineAuthContext<A, R>.(P, B) -> Unit
+    @PublishedApi
+    internal fun <P : Any, R : Any, B : Any> handle(
+        pType: KType,
+        rType: KType,
+        bType: KType,
+        body: suspend OpenAPIPipelineAuthContext<A, R>.(P, B) -> Unit
     ) {
         child().apply {// child in case path is branch to prevent propagation of the mutable nature of the provider
             provider.registerModule(authProvider)
-            handle<P, R, B>(pClass, rClass, bClass) { pipeline, responder, p, b ->
+            handle<P, R, B>(
+                pType,
+                rType,
+                bType
+            ) { pipeline, responder, p, b ->
                 AuthResponseContextImpl<A, R>(pipeline, authProvider, this, responder).body(p, b)
             }
         }
     }
 
-    inline fun <P : Any, R : Any> handle(
-        pClass: KClass<P>,
-        rClass: KClass<R>,
-        crossinline body: suspend OpenAPIPipelineAuthContext<A, R>.(P) -> Unit
+    @PublishedApi
+    internal fun <P : Any, R : Any> handle(
+        pType: KType,
+        rType: KType,
+        body: suspend OpenAPIPipelineAuthContext<A, R>.(P) -> Unit
     ) {
         child().apply {// child in case path is branch to prevent propagation of the mutable nature of the provider
             provider.registerModule(authProvider)
-            handle<P, R, Unit>(pClass, rClass, Unit::class) { pipeline, responder, p: P, _ ->
+            handle<P, R, Unit>(
+                pType,
+                rType,
+                typeOf<Unit>()
+            ) { pipeline, responder, p: P, _ ->
                 AuthResponseContextImpl<A, R>(pipeline, authProvider, this, responder).body(p)
             }
         }

--- a/src/main/kotlin/com/papsign/ktor/openapigen/route/path/normal/Functions.kt
+++ b/src/main/kotlin/com/papsign/ktor/openapigen/route/path/normal/Functions.kt
@@ -7,13 +7,14 @@ import com.papsign.ktor.openapigen.route.response.OpenAPIPipelineResponseContext
 import io.ktor.http.HttpMethod
 import io.ktor.util.pipeline.ContextDsl
 import kotlin.reflect.full.starProjectedType
+import kotlin.reflect.typeOf
 
 
 @ContextDsl
 inline fun <reified P : Any, reified R : Any> NormalOpenAPIRoute.get(
     vararg modules: RouteOpenAPIModule,
     example: R? = null,
-    crossinline body: suspend OpenAPIPipelineResponseContext<R>.(P) -> Unit
+    noinline body: suspend OpenAPIPipelineResponseContext<R>.(P) -> Unit
 ) = route(HttpMethod.Get, modules, example, body)
 
 @ContextDsl
@@ -21,7 +22,7 @@ inline fun <reified P : Any, reified R : Any, reified B : Any> NormalOpenAPIRout
     vararg modules: RouteOpenAPIModule,
     exampleResponse: R? = null,
     exampleRequest: B? = null,
-    crossinline body: suspend OpenAPIPipelineResponseContext<R>.(P, B) -> Unit
+    noinline body: suspend OpenAPIPipelineResponseContext<R>.(P, B) -> Unit
 ) = route(HttpMethod.Post, modules, exampleResponse, exampleRequest, body)
 
 @ContextDsl
@@ -29,7 +30,7 @@ inline fun <reified P : Any, reified R : Any, reified B : Any> NormalOpenAPIRout
     vararg modules: RouteOpenAPIModule,
     exampleResponse: R? = null,
     exampleRequest: B? = null,
-    crossinline body: suspend OpenAPIPipelineResponseContext<R>.(P, B) -> Unit
+    noinline body: suspend OpenAPIPipelineResponseContext<R>.(P, B) -> Unit
 ) = route(HttpMethod.Put, modules, exampleResponse, exampleRequest, body)
 
 @ContextDsl
@@ -37,21 +38,21 @@ inline fun <reified P : Any, reified R : Any, reified B : Any> NormalOpenAPIRout
     vararg modules: RouteOpenAPIModule,
     exampleResponse: R? = null,
     exampleRequest: B? = null,
-    crossinline body: suspend OpenAPIPipelineResponseContext<R>.(P, B) -> Unit
+    noinline body: suspend OpenAPIPipelineResponseContext<R>.(P, B) -> Unit
 ) = route(HttpMethod.Patch, modules, exampleResponse, exampleRequest, body)
 
 @ContextDsl
 inline fun <reified P : Any, reified R : Any> NormalOpenAPIRoute.delete(
     vararg modules: RouteOpenAPIModule,
     example: R? = null,
-    crossinline body: suspend OpenAPIPipelineResponseContext<R>.(P) -> Unit
+    noinline body: suspend OpenAPIPipelineResponseContext<R>.(P) -> Unit
 ) = route(HttpMethod.Delete, modules, example, body)
 
 @ContextDsl
 inline fun <reified P : Any, reified R : Any> NormalOpenAPIRoute.head(
     vararg modules: RouteOpenAPIModule,
     example: R? = null,
-    crossinline body: suspend OpenAPIPipelineResponseContext<R>.(P) -> Unit
+    noinline body: suspend OpenAPIPipelineResponseContext<R>.(P) -> Unit
 ) = route(HttpMethod.Head, modules, example, body)
 
 @ContextDsl
@@ -60,9 +61,10 @@ inline fun <reified P : Any, reified R : Any, reified B : Any> NormalOpenAPIRout
     modules: Array<out RouteOpenAPIModule>,
     exampleResponse: R? = null,
     exampleRequest: B? = null,
-    crossinline body: suspend OpenAPIPipelineResponseContext<R>.(P, B) -> Unit
+    noinline body: suspend OpenAPIPipelineResponseContext<R>.(P, B) -> Unit
 ) {
-    method(method).apply { modules.forEach { provider.registerModule(it, it::class.starProjectedType) } }.handle(exampleResponse, exampleRequest, body)
+    method(method).apply { modules.forEach { provider.registerModule(it, it::class.starProjectedType) } }
+        .handle(exampleResponse, exampleRequest, body)
 }
 
 @ContextDsl
@@ -70,28 +72,29 @@ inline fun <reified P : Any, reified R : Any> NormalOpenAPIRoute.route(
     method: HttpMethod,
     modules: Array<out RouteOpenAPIModule>,
     exampleResponse: R? = null,
-    crossinline body: suspend OpenAPIPipelineResponseContext<R>.(P) -> Unit
+    noinline body: suspend OpenAPIPipelineResponseContext<R>.(P) -> Unit
 ) {
-    method(method).apply { modules.forEach { provider.registerModule(it, it::class.starProjectedType) } }.handle(exampleResponse, body)
+    method(method).apply { modules.forEach { provider.registerModule(it, it::class.starProjectedType) } }
+        .handle(exampleResponse, body)
 }
 
 @ContextDsl
 inline fun <reified P : Any, reified R : Any, reified B : Any> NormalOpenAPIRoute.handle(
     exampleResponse: R? = null,
     exampleRequest: B? = null,
-    crossinline body: suspend OpenAPIPipelineResponseContext<R>.(P, B) -> Unit
+    noinline body: suspend OpenAPIPipelineResponseContext<R>.(P, B) -> Unit
 ) {
     preHandle<P, R, B, NormalOpenAPIRoute>(exampleResponse, exampleRequest) {
-        handle(P::class, R::class, B::class, body)
+        handle(typeOf<P>(), typeOf<R>(), typeOf<B>(), body)
     }
 }
 
 @ContextDsl
 inline fun <reified P : Any, reified R : Any> NormalOpenAPIRoute.handle(
     exampleResponse: R? = null,
-    crossinline body: suspend OpenAPIPipelineResponseContext<R>.(P) -> Unit
+    noinline body: suspend OpenAPIPipelineResponseContext<R>.(P) -> Unit
 ) {
     preHandle<P, R, Unit, NormalOpenAPIRoute>(exampleResponse, Unit) {
-        handle(P::class, R::class, body)
+        handle(typeOf<P>(), typeOf<R>(), body)
     }
 }

--- a/src/main/kotlin/com/papsign/ktor/openapigen/route/path/normal/Functions.kt
+++ b/src/main/kotlin/com/papsign/ktor/openapigen/route/path/normal/Functions.kt
@@ -82,7 +82,7 @@ inline fun <reified P : Any, reified R : Any, reified B : Any> NormalOpenAPIRout
     crossinline body: suspend OpenAPIPipelineResponseContext<R>.(P, B) -> Unit
 ) {
     preHandle<P, R, B, NormalOpenAPIRoute>(exampleResponse, exampleRequest) {
-        handle(body)
+        handle(P::class, R::class, B::class, body)
     }
 }
 
@@ -92,6 +92,6 @@ inline fun <reified P : Any, reified R : Any> NormalOpenAPIRoute.handle(
     crossinline body: suspend OpenAPIPipelineResponseContext<R>.(P) -> Unit
 ) {
     preHandle<P, R, Unit, NormalOpenAPIRoute>(exampleResponse, Unit) {
-        handle(body)
+        handle(P::class, R::class, body)
     }
 }

--- a/src/main/kotlin/com/papsign/ktor/openapigen/route/path/normal/NormalOpenAPIRoute.kt
+++ b/src/main/kotlin/com/papsign/ktor/openapigen/route/path/normal/NormalOpenAPIRoute.kt
@@ -5,7 +5,8 @@ import com.papsign.ktor.openapigen.route.OpenAPIRoute
 import com.papsign.ktor.openapigen.route.response.OpenAPIPipelineResponseContext
 import com.papsign.ktor.openapigen.route.response.ResponseContextImpl
 import io.ktor.routing.Route
-import kotlin.reflect.KClass
+import kotlin.reflect.KType
+import kotlin.reflect.typeOf
 
 class NormalOpenAPIRoute(route: Route, provider: CachingModuleProvider = CachingModuleProvider()) :
     OpenAPIRoute<NormalOpenAPIRoute>(route, provider) {
@@ -14,23 +15,25 @@ class NormalOpenAPIRoute(route: Route, provider: CachingModuleProvider = Caching
         return NormalOpenAPIRoute(route, provider.child())
     }
 
-    inline fun <P : Any, R : Any, B : Any> handle(
-        pClass: KClass<P>,
-        rClass: KClass<R>,
-        bClass: KClass<B>,
-        crossinline body: suspend OpenAPIPipelineResponseContext<R>.(P, B) -> Unit
+    @PublishedApi
+    internal fun <P : Any, R : Any, B : Any> handle(
+        pType: KType,
+        rType: KType,
+        bType: KType,
+        body: suspend OpenAPIPipelineResponseContext<R>.(P, B) -> Unit
     ) {
-        handle<P, R, B>(pClass, rClass, bClass) { pipeline, responder, p, b ->
+        handle<P, R, B>(pType, rType, bType) { pipeline, responder, p, b ->
             ResponseContextImpl<R>(pipeline, this, responder).body(p, b)
         }
     }
 
-    inline fun <P : Any, R : Any> handle(
-        pClass: KClass<P>,
-        rClass: KClass<R>,
-        crossinline body: suspend OpenAPIPipelineResponseContext<R>.(P) -> Unit
+    @PublishedApi
+    internal fun <P : Any, R : Any> handle(
+        pType: KType,
+        rType: KType,
+        body: suspend OpenAPIPipelineResponseContext<R>.(P) -> Unit
     ) {
-        handle<P, R, Unit>(pClass, rClass, Unit::class) { pipeline, responder, p, _ ->
+        handle<P, R, Unit>(pType, rType, typeOf<Unit>()) { pipeline, responder, p, _ ->
             ResponseContextImpl<R>(pipeline, this, responder).body(p)
         }
     }

--- a/src/main/kotlin/com/papsign/ktor/openapigen/route/path/normal/NormalOpenAPIRoute.kt
+++ b/src/main/kotlin/com/papsign/ktor/openapigen/route/path/normal/NormalOpenAPIRoute.kt
@@ -5,21 +5,32 @@ import com.papsign.ktor.openapigen.route.OpenAPIRoute
 import com.papsign.ktor.openapigen.route.response.OpenAPIPipelineResponseContext
 import com.papsign.ktor.openapigen.route.response.ResponseContextImpl
 import io.ktor.routing.Route
+import kotlin.reflect.KClass
 
-class NormalOpenAPIRoute(route: Route, provider: CachingModuleProvider = CachingModuleProvider()): OpenAPIRoute<NormalOpenAPIRoute>(route, provider) {
+class NormalOpenAPIRoute(route: Route, provider: CachingModuleProvider = CachingModuleProvider()) :
+    OpenAPIRoute<NormalOpenAPIRoute>(route, provider) {
 
     override fun child(route: Route): NormalOpenAPIRoute {
         return NormalOpenAPIRoute(route, provider.child())
     }
 
-    inline fun <reified P : Any, reified R: Any, reified B : Any> handle(crossinline body: suspend OpenAPIPipelineResponseContext<R>.(P, B) -> Unit) {
-        handle<P, R, B> {pipeline, responder, p, b ->
+    inline fun <P : Any, R : Any, B : Any> handle(
+        pClass: KClass<P>,
+        rClass: KClass<R>,
+        bClass: KClass<B>,
+        crossinline body: suspend OpenAPIPipelineResponseContext<R>.(P, B) -> Unit
+    ) {
+        handle<P, R, B>(pClass, rClass, bClass) { pipeline, responder, p, b ->
             ResponseContextImpl<R>(pipeline, this, responder).body(p, b)
         }
     }
 
-    inline fun <reified P : Any, reified R: Any> handle(crossinline body: suspend OpenAPIPipelineResponseContext<R>.(P) -> Unit) {
-        handle<P, R, Unit> {pipeline, responder, p, _ ->
+    inline fun <P : Any, R : Any> handle(
+        pClass: KClass<P>,
+        rClass: KClass<R>,
+        crossinline body: suspend OpenAPIPipelineResponseContext<R>.(P) -> Unit
+    ) {
+        handle<P, R, Unit>(pClass, rClass, Unit::class) { pipeline, responder, p, _ ->
             ResponseContextImpl<R>(pipeline, this, responder).body(p)
         }
     }

--- a/src/main/kotlin/com/papsign/ktor/openapigen/validation/ValidationHandler.kt
+++ b/src/main/kotlin/com/papsign/ktor/openapigen/validation/ValidationHandler.kt
@@ -281,8 +281,8 @@ class ValidationHandler private constructor(
                 get() = classAnnotation + typeAnnotation + additionalAnnotations
 
             companion object {
-                inline operator fun <reified T> invoke(annotations: List<Annotation> = listOf()): AnnotatedKType {
-                    val type = getKType<T>()
+                operator fun <T:Any> invoke(tClass: KClass<T>, annotations: List<Annotation> = listOf()): AnnotatedKType {
+                    val type = tClass.starProjectedType
                     return AnnotatedKType(
                         type,
                         annotations
@@ -313,9 +313,10 @@ class ValidationHandler private constructor(
             }()
         }
 
-        inline fun <reified T> build(annotations: List<Annotation> = listOf()): ValidationHandler {
+        inline fun <T:Any> build(tClass: KClass<T>, annotations: List<Annotation> = listOf()): ValidationHandler {
             return build(
-                AnnotatedKType<T>(
+                AnnotatedKType(
+                    tClass.starProjectedType,
                     annotations
                 )
             )

--- a/src/main/kotlin/com/papsign/ktor/openapigen/validation/ValidationHandler.kt
+++ b/src/main/kotlin/com/papsign/ktor/openapigen/validation/ValidationHandler.kt
@@ -237,6 +237,7 @@ class ValidationHandler private constructor(
                         transformFun = { t: Any? ->
                             if (t != null) {
                                 handled.forEach { (handler, field) ->
+                                    // TODO convert this to canAccess and only change status if false
                                     val accessible = field.isAccessible
                                     field.isAccessible = true
                                     field.set(t, handler.handle(field.get(t)))
@@ -313,7 +314,7 @@ class ValidationHandler private constructor(
             }()
         }
 
-        inline fun <T:Any> build(tClass: KClass<T>, annotations: List<Annotation> = listOf()): ValidationHandler {
+        fun <T:Any> build(tClass: KClass<T>, annotations: List<Annotation> = listOf()): ValidationHandler {
             return build(
                 AnnotatedKType(
                     tClass.starProjectedType,

--- a/src/test/kotlin/com/papsign/ktor/openapigen/routing/GenericsTest.kt
+++ b/src/test/kotlin/com/papsign/ktor/openapigen/routing/GenericsTest.kt
@@ -1,0 +1,85 @@
+package com.papsign.ktor.openapigen.routing
+
+import com.papsign.ktor.openapigen.annotations.parameters.HeaderParam
+import com.papsign.ktor.openapigen.route.apiRouting
+import com.papsign.ktor.openapigen.route.path.normal.post
+import com.papsign.ktor.openapigen.route.response.respond
+import com.papsign.ktor.openapigen.route.route
+import installJackson
+import installOpenAPI
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpMethod
+import io.ktor.routing.Routing
+import io.ktor.server.testing.contentType
+import io.ktor.server.testing.handleRequest
+import io.ktor.server.testing.setBody
+import io.ktor.server.testing.withTestApplication
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import kotlin.test.assertTrue
+
+class GenericsTest {
+
+    data class TestHeaderParams(@HeaderParam("test param") val `Test-Header`: MutableList<Long>)
+
+    @Test
+    fun testTypedMap() {
+        val route = "/test"
+        withTestApplication({
+            installOpenAPI()
+            installJackson()
+            apiRouting {
+                (this.ktorRoute as Routing).trace { println(it.buildText()) }
+                route(route) {
+                    post<TestHeaderParams, List<String>, Map<String, String>> { params, body ->
+                        respond(mutableListOf(params.toString(), body.toString()))
+                    }
+                }
+            }
+        }) {
+            handleRequest(HttpMethod.Post, route) {
+                addHeader(HttpHeaders.ContentType, "application/json")
+                addHeader(HttpHeaders.Accept, "application/json")
+                addHeader("Test-Header", "1,2,3")
+                setBody("{\"xyz\":456}")
+            }.apply {
+                assertTrue { response.contentType().match("application/json") }
+                assertEquals(
+                    "[\"TestHeaderParams(Test-Header=[1, 2, 3])\",\"{xyz=456}\"]",
+                    response.content
+                )
+            }
+        }
+    }
+
+    @Test
+    fun testTypedList() {
+        val route = "/test"
+        withTestApplication({
+            installOpenAPI()
+            installJackson()
+            apiRouting {
+                (this.ktorRoute as Routing).trace { println(it.buildText()) }
+                route(route) {
+                    post<TestHeaderParams, List<String>, List<String>> { params, body ->
+                        respond(mutableListOf(params.toString(), body.toString()))
+                    }
+                }
+            }
+        }) {
+            handleRequest(HttpMethod.Post, route) {
+                addHeader(HttpHeaders.ContentType, "application/json")
+                addHeader(HttpHeaders.Accept, "application/json")
+                addHeader("Test-Header", "1,2,3")
+                setBody("[\"a\",\"b\",\"c\"]")
+            }.apply {
+                assertTrue { response.contentType().match("application/json") }
+                assertEquals(
+                    "[\"TestHeaderParams(Test-Header=[1, 2, 3])\",\"[a, b, c]\"]",
+                    response.content
+                )
+            }
+        }
+    }
+
+}

--- a/src/test/kotlin/com/papsign/ktor/openapigen/routing/RoutingTest.kt
+++ b/src/test/kotlin/com/papsign/ktor/openapigen/routing/RoutingTest.kt
@@ -1,0 +1,56 @@
+package com.papsign.ktor.openapigen.routing
+
+import com.papsign.ktor.openapigen.annotations.parameters.HeaderParam
+import com.papsign.ktor.openapigen.route.apiRouting
+import com.papsign.ktor.openapigen.route.path.normal.post
+import com.papsign.ktor.openapigen.route.response.respond
+import com.papsign.ktor.openapigen.route.route
+import installJackson
+import installOpenAPI
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpMethod
+import io.ktor.routing.Routing
+import io.ktor.server.testing.contentType
+import io.ktor.server.testing.handleRequest
+import io.ktor.server.testing.setBody
+import io.ktor.server.testing.withTestApplication
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import kotlin.test.assertTrue
+
+class RoutingTest {
+
+    data class TestHeaderParams(@HeaderParam("test param") val `Test-Header`: Long)
+    data class TestBodyParams(val xyz: Long)
+    data class TestResponse(val msg: String)
+
+    @Test
+    fun testPostWithHeaderAndBodyParams() {
+        val route = "/test"
+        withTestApplication({
+            installOpenAPI()
+            installJackson()
+            apiRouting {
+                (this.ktorRoute as Routing).trace { println(it.buildText()) }
+                route(route) {
+                    post<TestHeaderParams, TestResponse, TestBodyParams> { params, body ->
+                        respond(TestResponse("$params -> $body"))
+                    }
+                }
+            }
+        }) {
+            handleRequest(HttpMethod.Post, route) {
+                addHeader(HttpHeaders.ContentType, "application/json")
+                addHeader(HttpHeaders.Accept, "application/json")
+                addHeader("Test-Header", "123")
+                setBody("{\"xyz\":456}")
+            }.apply {
+                assertTrue { response.contentType().match("application/json") }
+                assertEquals(
+                    "{\"msg\":\"${TestHeaderParams(123)} -> ${TestBodyParams(456)}\"}",
+                    response.content
+                )
+            }
+        }
+    }
+}

--- a/src/test/kotlin/com/papsign/ktor/openapigen/routing/RoutingTest.kt
+++ b/src/test/kotlin/com/papsign/ktor/openapigen/routing/RoutingTest.kt
@@ -2,6 +2,7 @@ package com.papsign.ktor.openapigen.routing
 
 import com.papsign.ktor.openapigen.annotations.parameters.HeaderParam
 import com.papsign.ktor.openapigen.route.apiRouting
+import com.papsign.ktor.openapigen.route.path.normal.get
 import com.papsign.ktor.openapigen.route.path.normal.post
 import com.papsign.ktor.openapigen.route.response.respond
 import com.papsign.ktor.openapigen.route.route
@@ -48,6 +49,88 @@ class RoutingTest {
                 assertTrue { response.contentType().match("application/json") }
                 assertEquals(
                     "{\"msg\":\"${TestHeaderParams(123)} -> ${TestBodyParams(456)}\"}",
+                    response.content
+                )
+            }
+        }
+    }
+
+    @Test
+    fun testGetWithHeaderParams() {
+        val route = "/test"
+        withTestApplication({
+            installOpenAPI()
+            installJackson()
+            apiRouting {
+                (this.ktorRoute as Routing).trace { println(it.buildText()) }
+                route(route) {
+                    get<TestHeaderParams, TestResponse> { params ->
+                        respond(TestResponse("$params"))
+                    }
+                }
+            }
+        }) {
+            handleRequest(HttpMethod.Get, route) {
+                addHeader(HttpHeaders.Accept, "application/json")
+                addHeader("Test-Header", "123")
+            }.apply {
+                assertTrue { response.contentType().match("application/json") }
+                assertEquals(
+                    "{\"msg\":\"${TestHeaderParams(123)}\"}",
+                    response.content
+                )
+            }
+        }
+    }
+
+    @Test
+    fun testPostWithUnitTypes() {
+        val route = "/test"
+        withTestApplication({
+            installOpenAPI()
+            installJackson()
+            apiRouting {
+                (this.ktorRoute as Routing).trace { println(it.buildText()) }
+                route(route) {
+                    post<Unit, TestResponse, Unit> { params, body ->
+                        respond(TestResponse("Test Response"))
+                    }
+                }
+            }
+        }) {
+            handleRequest(HttpMethod.Post, route) {
+                addHeader(HttpHeaders.Accept, "application/json")
+            }.apply {
+                assertTrue { response.contentType().match("application/json") }
+                assertEquals(
+                    "{\"msg\":\"Test Response\"}",
+                    response.content
+                )
+            }
+        }
+    }
+
+    @Test
+    fun testGetWithUnitTypes() {
+        val route = "/test"
+        withTestApplication({
+            installOpenAPI()
+            installJackson()
+            apiRouting {
+                (this.ktorRoute as Routing).trace { println(it.buildText()) }
+                route(route) {
+                    get<Unit, TestResponse> { params ->
+                        respond(TestResponse("Test Response"))
+                    }
+                }
+            }
+        }) {
+            handleRequest(HttpMethod.Get, route) {
+                addHeader(HttpHeaders.Accept, "application/json")
+            }.apply {
+                assertTrue { response.contentType().match("application/json") }
+                assertEquals(
+                    "{\"msg\":\"Test Response\"}",
                     response.content
                 )
             }


### PR DESCRIPTION
When building routes with reflection instead of manually registering them it is not possible to use reified DSL because it is not available at runtime using reflection. This can be fixed by only using reified for DSL methods and passing the class instance as parameters. This would allow external code to build routes from for example something like this:

```kotlin
@Controller("/test")
class TestController {
    @Throws(TestException::class, TestExceptionHandler::class) 
    @Route("info", RouteHttpMethod.GET, "example info", "example description")
    fun testRoute(params: String, body: String, ctx: APIRequestContext): String {
        return params
    }
}
```

There is no impact to the current DSL and there should be no performance impact, since this only affects the route building.