### PR TITLE
Changing test server to correct JWT bearer auth config.

### DIFF
--- a/src/test/kotlin/JwtAuthDocumentationGenerationTest.kt
+++ b/src/test/kotlin/JwtAuthDocumentationGenerationTest.kt
@@ -18,11 +18,11 @@ internal class JwtAuthDocumentationGenerationTest {
         with(handleRequest(HttpMethod.Get, "//openapi.json")) {
             assertEquals(HttpStatusCode.OK, response.status())
             assertTrue(response.content!!.contains("\"securitySchemes\" : {\n" +
-                    "      \"JWT\" : {\n" +
+                    "      \"jwtAuth\" : {\n" +
                     "        \"bearerFormat\" : \"JWT\",\n" +
-                    "        \"name\" : \"JWT\",\n" +
+                    "        \"name\" : \"jwtAuth\",\n" +
                     "        \"scheme\" : \"bearer\",\n" +
-                    "        \"type\" : \"openIdConnect\"\n" +
+                    "        \"type\" : \"http\"\n" +
                     "      }\n" +
                     "    }"))
             assertTrue(response.content!!.contains("\"security\" : [ { } ],"))

--- a/src/test/kotlin/TestServerWithJwtAuth.kt
+++ b/src/test/kotlin/TestServerWithJwtAuth.kt
@@ -162,10 +162,10 @@ object TestServerWithJwtAuth {
             listOf(listOf(
                 AuthProvider.Security(
                     SecuritySchemeModel(
-                        SecuritySchemeType.openIdConnect,
+                        SecuritySchemeType.http,
                         scheme = HttpSecurityScheme.bearer,
                         bearerFormat = "JWT",
-                        name = "JWT"
+                        name = "jwtAuth"
                     ), emptyList<Scopes>()
                 )
             ))


### PR DESCRIPTION
Bearer authentication should be done with the http type, not openIdConnect, now fixed in test server. Also changing name to a unique value to avoid confusion (it was previously equal to the bearerFormat).