### PR TITLE
Allow nullable parameters

### DIFF
--- a/src/main/kotlin/com/papsign/ktor/openapigen/parameters/handlers/ModularParameterHandler.kt
+++ b/src/main/kotlin/com/papsign/ktor/openapigen/parameters/handlers/ModularParameterHandler.kt
@@ -28,8 +28,9 @@ class ModularParameterHandler<T>(val parsers: Map<KParameter, Builder<*>>, val c
 
     override fun parse(parameters: Parameters, headers: Headers): T {
         return constructor.callBy(parsers.mapValues {
-            it.value.build(it.key.name.toString(), it.key.remapOpenAPINames(parameters.toMap() + headers.toMap()))
-                ?: throw OpenAPIRequiredFieldException("""The field ${it.key.openAPIName ?: "unknow field"} is required""")
+            val value = it.value.build(it.key.name.toString(), it.key.remapOpenAPINames(parameters.toMap() + headers.toMap()))
+            if (value==null && (!it.key.type.isMarkedNullable)) throw OpenAPIRequiredFieldException("""The field ${it.key.openAPIName ?: "unknown field"} is required""")
+            value
         })
     }
 


### PR DESCRIPTION
Like reported by @msramosjr We need check if the value o parameter is nullable before throw exception.

This fix the Minimal.kt example. So we are able to allow nullable fields, like follow code:

```
@Path("string/{a}")
    data class StringParam(
        @PathParam("A simple String Param") val a: String,
        @QueryParam("Optional String") val optional: String? // Nullable Types are optional
    )
```

Thank you.
