### PR TITLE
Fixed filling the schema model with annotations for query and params

### DIFF
--- a/src/main/kotlin/com/papsign/ktor/openapigen/annotations/properties/description/Description.kt
+++ b/src/main/kotlin/com/papsign/ktor/openapigen/annotations/properties/description/Description.kt
@@ -5,6 +5,6 @@ import com.papsign.ktor.openapigen.schema.processor.SchemaProcessorAnnotation
 /**
  * Property annotation for providing a description of a schema model property
  */
-@Target(AnnotationTarget.PROPERTY)
+@Target(AnnotationTarget.PROPERTY, AnnotationTarget.VALUE_PARAMETER)
 @SchemaProcessorAnnotation(DescriptionProcessor::class)
 annotation class Description(val value: String)

--- a/src/main/kotlin/com/papsign/ktor/openapigen/annotations/type/number/floating/clamp/FClamp.kt
+++ b/src/main/kotlin/com/papsign/ktor/openapigen/annotations/type/number/floating/clamp/FClamp.kt
@@ -3,7 +3,7 @@ package com.papsign.ktor.openapigen.annotations.type.number.floating.clamp
 import com.papsign.ktor.openapigen.schema.processor.SchemaProcessorAnnotation
 import com.papsign.ktor.openapigen.validation.ValidatorAnnotation
 
-@Target(AnnotationTarget.TYPE, AnnotationTarget.PROPERTY)
+@Target(AnnotationTarget.TYPE, AnnotationTarget.PROPERTY, AnnotationTarget.VALUE_PARAMETER)
 @SchemaProcessorAnnotation(FClampProcessor::class)
 @ValidatorAnnotation(FClampProcessor::class)
 annotation class FClamp(val min: Double, val max: Double, val errorMessage: String = "")

--- a/src/main/kotlin/com/papsign/ktor/openapigen/annotations/type/number/floating/max/FMax.kt
+++ b/src/main/kotlin/com/papsign/ktor/openapigen/annotations/type/number/floating/max/FMax.kt
@@ -3,7 +3,7 @@ package com.papsign.ktor.openapigen.annotations.type.number.floating.max
 import com.papsign.ktor.openapigen.schema.processor.SchemaProcessorAnnotation
 import com.papsign.ktor.openapigen.validation.ValidatorAnnotation
 
-@Target(AnnotationTarget.TYPE, AnnotationTarget.PROPERTY)
+@Target(AnnotationTarget.TYPE, AnnotationTarget.PROPERTY, AnnotationTarget.VALUE_PARAMETER)
 @SchemaProcessorAnnotation(FMaxProcessor::class)
 @ValidatorAnnotation(FMaxProcessor::class)
 annotation class FMax(val value: Double, val errorMessage: String = "")

--- a/src/main/kotlin/com/papsign/ktor/openapigen/annotations/type/number/floating/min/FMin.kt
+++ b/src/main/kotlin/com/papsign/ktor/openapigen/annotations/type/number/floating/min/FMin.kt
@@ -3,7 +3,7 @@ package com.papsign.ktor.openapigen.annotations.type.number.floating.min
 import com.papsign.ktor.openapigen.schema.processor.SchemaProcessorAnnotation
 import com.papsign.ktor.openapigen.validation.ValidatorAnnotation
 
-@Target(AnnotationTarget.TYPE, AnnotationTarget.PROPERTY)
+@Target(AnnotationTarget.TYPE, AnnotationTarget.PROPERTY, AnnotationTarget.VALUE_PARAMETER)
 @SchemaProcessorAnnotation(FMinProcessor::class)
 @ValidatorAnnotation(FMinProcessor::class)
 annotation class FMin(val value: Double, val errorMessage: String = "")

--- a/src/main/kotlin/com/papsign/ktor/openapigen/annotations/type/number/integer/clamp/Clamp.kt
+++ b/src/main/kotlin/com/papsign/ktor/openapigen/annotations/type/number/integer/clamp/Clamp.kt
@@ -3,7 +3,7 @@ package com.papsign.ktor.openapigen.annotations.type.number.integer.clamp
 import com.papsign.ktor.openapigen.schema.processor.SchemaProcessorAnnotation
 import com.papsign.ktor.openapigen.validation.ValidatorAnnotation
 
-@Target(AnnotationTarget.TYPE, AnnotationTarget.PROPERTY)
+@Target(AnnotationTarget.TYPE, AnnotationTarget.PROPERTY, AnnotationTarget.VALUE_PARAMETER)
 @SchemaProcessorAnnotation(ClampProcessor::class)
 @ValidatorAnnotation(ClampProcessor::class)
 annotation class Clamp(val min: Long, val max: Long, val errorMessage: String = "")

--- a/src/main/kotlin/com/papsign/ktor/openapigen/annotations/type/number/integer/max/Max.kt
+++ b/src/main/kotlin/com/papsign/ktor/openapigen/annotations/type/number/integer/max/Max.kt
@@ -3,7 +3,7 @@ package com.papsign.ktor.openapigen.annotations.type.number.integer.max
 import com.papsign.ktor.openapigen.schema.processor.SchemaProcessorAnnotation
 import com.papsign.ktor.openapigen.validation.ValidatorAnnotation
 
-@Target(AnnotationTarget.TYPE, AnnotationTarget.PROPERTY)
+@Target(AnnotationTarget.TYPE, AnnotationTarget.PROPERTY, AnnotationTarget.VALUE_PARAMETER)
 @SchemaProcessorAnnotation(MaxProcessor::class)
 @ValidatorAnnotation(MaxProcessor::class)
 annotation class Max(val value: Long, val errorMessage: String = "")

--- a/src/main/kotlin/com/papsign/ktor/openapigen/annotations/type/number/integer/min/Min.kt
+++ b/src/main/kotlin/com/papsign/ktor/openapigen/annotations/type/number/integer/min/Min.kt
@@ -3,7 +3,7 @@ package com.papsign.ktor.openapigen.annotations.type.number.integer.min
 import com.papsign.ktor.openapigen.schema.processor.SchemaProcessorAnnotation
 import com.papsign.ktor.openapigen.validation.ValidatorAnnotation
 
-@Target(AnnotationTarget.TYPE, AnnotationTarget.PROPERTY)
+@Target(AnnotationTarget.TYPE, AnnotationTarget.PROPERTY, AnnotationTarget.VALUE_PARAMETER)
 @SchemaProcessorAnnotation(MinProcessor::class)
 @ValidatorAnnotation(MinProcessor::class)
 annotation class Min(val value: Long, val errorMessage: String = "")

--- a/src/main/kotlin/com/papsign/ktor/openapigen/annotations/type/object/example/WithExample.kt
+++ b/src/main/kotlin/com/papsign/ktor/openapigen/annotations/type/object/example/WithExample.kt
@@ -6,7 +6,7 @@ import kotlin.reflect.KClass
 /**
  * Careful, no type checking done if you give the wrong provider
  */
-@Target(AnnotationTarget.CLASS, AnnotationTarget.TYPE, AnnotationTarget.PROPERTY)
+@Target(AnnotationTarget.CLASS, AnnotationTarget.TYPE, AnnotationTarget.PROPERTY, AnnotationTarget.VALUE_PARAMETER)
 @SchemaProcessorAnnotation(ExampleProcessor::class)
 annotation class WithExample(val provider: KClass<out ExampleProvider<*>> = NoExampleProvider::class)
 

--- a/src/main/kotlin/com/papsign/ktor/openapigen/annotations/type/string/example/StringExample.kt
+++ b/src/main/kotlin/com/papsign/ktor/openapigen/annotations/type/string/example/StringExample.kt
@@ -5,6 +5,6 @@ import com.papsign.ktor.openapigen.schema.processor.SchemaProcessorAnnotation
 /**
  * Provide examples for a String property
  */
-@Target(AnnotationTarget.PROPERTY)
+@Target(AnnotationTarget.PROPERTY, AnnotationTarget.VALUE_PARAMETER)
 @SchemaProcessorAnnotation(StringExampleProcessor::class)
 annotation class StringExample(vararg val examples: String)

--- a/src/main/kotlin/com/papsign/ktor/openapigen/annotations/type/string/length/Length.kt
+++ b/src/main/kotlin/com/papsign/ktor/openapigen/annotations/type/string/length/Length.kt
@@ -3,7 +3,7 @@ package com.papsign.ktor.openapigen.annotations.type.string.length
 import com.papsign.ktor.openapigen.schema.processor.SchemaProcessorAnnotation
 import com.papsign.ktor.openapigen.validation.ValidatorAnnotation
 
-@Target(AnnotationTarget.TYPE, AnnotationTarget.PROPERTY)
+@Target(AnnotationTarget.TYPE, AnnotationTarget.PROPERTY, AnnotationTarget.VALUE_PARAMETER)
 @SchemaProcessorAnnotation(LengthProcessor::class)
 @ValidatorAnnotation(LengthProcessor::class)
 annotation class Length(val min: Int, val max: Int, val errorMessage: String = "")

--- a/src/main/kotlin/com/papsign/ktor/openapigen/annotations/type/string/length/MaxLength.kt
+++ b/src/main/kotlin/com/papsign/ktor/openapigen/annotations/type/string/length/MaxLength.kt
@@ -3,7 +3,7 @@ package com.papsign.ktor.openapigen.annotations.type.string.length
 import com.papsign.ktor.openapigen.schema.processor.SchemaProcessorAnnotation
 import com.papsign.ktor.openapigen.validation.ValidatorAnnotation
 
-@Target(AnnotationTarget.TYPE, AnnotationTarget.PROPERTY)
+@Target(AnnotationTarget.TYPE, AnnotationTarget.PROPERTY, AnnotationTarget.VALUE_PARAMETER)
 @SchemaProcessorAnnotation(MaxLengthProcessor::class)
 @ValidatorAnnotation(MaxLengthProcessor::class)
 annotation class MaxLength(val value: Int, val errorMessage: String = "")

--- a/src/main/kotlin/com/papsign/ktor/openapigen/annotations/type/string/length/MinLength.kt
+++ b/src/main/kotlin/com/papsign/ktor/openapigen/annotations/type/string/length/MinLength.kt
@@ -3,7 +3,7 @@ package com.papsign.ktor.openapigen.annotations.type.string.length
 import com.papsign.ktor.openapigen.schema.processor.SchemaProcessorAnnotation
 import com.papsign.ktor.openapigen.validation.ValidatorAnnotation
 
-@Target(AnnotationTarget.TYPE, AnnotationTarget.PROPERTY)
+@Target(AnnotationTarget.TYPE, AnnotationTarget.PROPERTY, AnnotationTarget.VALUE_PARAMETER)
 @SchemaProcessorAnnotation(MinLengthProcessor::class)
 @ValidatorAnnotation(MinLengthProcessor::class)
 annotation class MinLength(val value: Int, val errorMessage: String = "")

--- a/src/main/kotlin/com/papsign/ktor/openapigen/annotations/type/string/pattern/RegularExpression.kt
+++ b/src/main/kotlin/com/papsign/ktor/openapigen/annotations/type/string/pattern/RegularExpression.kt
@@ -3,7 +3,7 @@ package com.papsign.ktor.openapigen.annotations.type.string.pattern
 import com.papsign.ktor.openapigen.schema.processor.SchemaProcessorAnnotation
 import com.papsign.ktor.openapigen.validation.ValidatorAnnotation
 
-@Target(AnnotationTarget.TYPE, AnnotationTarget.PROPERTY)
+@Target(AnnotationTarget.TYPE, AnnotationTarget.PROPERTY, AnnotationTarget.VALUE_PARAMETER)
 @SchemaProcessorAnnotation(RegularExpressionProcessor::class)
 @ValidatorAnnotation(RegularExpressionProcessor::class)
 annotation class RegularExpression(@org.intellij.lang.annotations.Language("RegExp") val pattern: String, val errorMessage: String = "")

--- a/src/main/kotlin/com/papsign/ktor/openapigen/parameters/handlers/ModularParameterHandler.kt
+++ b/src/main/kotlin/com/papsign/ktor/openapigen/parameters/handlers/ModularParameterHandler.kt
@@ -47,7 +47,7 @@ class ModularParameterHandler<T>(val parsers: Map<KParameter, Builder<*>>, val c
                 !param.type.isMarkedNullable
             ).also {
                 @Suppress("UNCHECKED_CAST")
-                it.schema = schemaBuilder.build(param.type.withNullability(false)) as SchemaModel<Any>
+                it.schema = schemaBuilder.build(param.type.withNullability(false), param.annotations) as SchemaModel<Any>
                 config(it)
             }
         }


### PR DESCRIPTION
When annotations are applied in this way, the corresponding parameters were not applied to the schema model.
```kotlin
@Path("string/{str}")
data class StringParam(
    @PathParam("A simple String Param")
    @MinLength(2)
    @MaxLength(10)
    val str: String,
)
```