### PR TITLE
Improvements for jwt

### DIFF
--- a/src/main/kotlin/com/papsign/ktor/openapigen/SerializationSettings.kt
+++ b/src/main/kotlin/com/papsign/ktor/openapigen/SerializationSettings.kt
@@ -4,8 +4,4 @@ data class SerializationSettings(
     val skipEmptyMap: Boolean = false,
     val skipEmptyList: Boolean = false,
     val skipEmptyValue: Boolean = false
-) {
-    companion object{
-        val default = SerializationSettings(false, false, false)
-    }
-}
+)

--- a/src/main/kotlin/com/papsign/ktor/openapigen/SerializationSettings.kt
+++ b/src/main/kotlin/com/papsign/ktor/openapigen/SerializationSettings.kt
@@ -1,0 +1,11 @@
+package com.papsign.ktor.openapigen
+
+data class SerializationSettings(
+    val skipEmptyMap: Boolean = false,
+    val skipEmptyList: Boolean = false,
+    val skipEmptyValue: Boolean = false
+) {
+    companion object{
+        val default = SerializationSettings(false, false, false)
+    }
+}

--- a/src/main/kotlin/com/papsign/ktor/openapigen/Util.kt
+++ b/src/main/kotlin/com/papsign/ktor/openapigen/Util.kt
@@ -17,7 +17,7 @@ internal inline fun <reified T> classLogger(): Logger {
     return LoggerFactory.getLogger(T::class.java)
 }
 
-fun Map<String, *>.cleanEmptyValues(serializationSettings: SerializationSettings = SerializationSettings.default): Map<String, *> {
+fun Map<String, *>.cleanEmptyValues(serializationSettings: SerializationSettings = SerializationSettings()): Map<String, *> {
     return filterValues {
         when (it) {
             is Map<*, *> -> it.isNotEmpty() || serializationSettings.skipEmptyMap
@@ -27,7 +27,7 @@ fun Map<String, *>.cleanEmptyValues(serializationSettings: SerializationSettings
     }
 }
 
-fun convertToValue(value: Any?, serializationSettings: SerializationSettings = SerializationSettings.default): Any? {
+fun convertToValue(value: Any?, serializationSettings: SerializationSettings = SerializationSettings()): Any? {
     return when (value) {
         is DataModel -> value.serialize()
         is Map<*, *> -> value.entries.associate { (key, value) -> Pair(key.toString(), convertToValue(value, serializationSettings)) }

--- a/src/main/kotlin/com/papsign/ktor/openapigen/Util.kt
+++ b/src/main/kotlin/com/papsign/ktor/openapigen/Util.kt
@@ -1,5 +1,6 @@
 package com.papsign.ktor.openapigen
 
+import com.papsign.ktor.openapigen.model.DataModel
 import io.ktor.application.Application
 import io.ktor.application.feature
 import org.slf4j.Logger
@@ -15,3 +16,24 @@ internal fun Any.classLogger(): Logger {
 internal inline fun <reified T> classLogger(): Logger {
     return LoggerFactory.getLogger(T::class.java)
 }
+
+fun Map<String, *>.cleanEmptyValues(serializationSettings: SerializationSettings = SerializationSettings.default): Map<String, *> {
+    return filterValues {
+        when (it) {
+            is Map<*, *> -> it.isNotEmpty() || serializationSettings.skipEmptyMap
+            is Collection<*> -> it.isNotEmpty() || serializationSettings.skipEmptyList
+            else -> it != null || serializationSettings.skipEmptyValue
+        }
+    }
+}
+
+fun convertToValue(value: Any?, serializationSettings: SerializationSettings = SerializationSettings.default): Any? {
+    return when (value) {
+        is DataModel -> value.serialize()
+        is Map<*, *> -> value.entries.associate { (key, value) -> Pair(key.toString(), convertToValue(value, serializationSettings)) }
+            .cleanEmptyValues(serializationSettings)
+        is Iterable<*> -> value.map { convertToValue(it, serializationSettings) }
+        else -> value
+    }
+}
+

--- a/src/main/kotlin/com/papsign/ktor/openapigen/model/DataModel.kt
+++ b/src/main/kotlin/com/papsign/ktor/openapigen/model/DataModel.kt
@@ -1,31 +1,15 @@
 package com.papsign.ktor.openapigen.model
 
-import com.papsign.ktor.openapigen.annotations.mapping.openAPIName
+import com.papsign.ktor.openapigen.cleanEmptyValues
+import com.papsign.ktor.openapigen.convertToValue
 import kotlin.reflect.KProperty1
 import kotlin.reflect.full.memberProperties
 
 interface DataModel {
 
     fun serialize(): Map<String, Any?> {
-        fun Map<String, *>.clean(): Map<String, *> {
-            return filterValues {
-                when (it) {
-                    is Map<*, *> -> it.isNotEmpty()
-                    is Collection<*> -> it.isNotEmpty()
-                    else -> it != null
-                }
-            }
-        }
-        fun cvt(value: Any?): Any? {
-            return when (value) {
-                is DataModel -> value.serialize()
-                is Map<*, *> -> value.entries.associate { (key, value) -> Pair(key.toString(), cvt(value)) }.clean()
-                is Iterable<*> -> value.map { cvt(it) }
-                else -> value
-            }
-        }
         return this::class.memberProperties.associateBy { it.name }.mapValues { (_, prop) ->
-            cvt((prop as KProperty1<DataModel, *>).get(this))
-        }.clean()
+            convertToValue((prop as KProperty1<DataModel, *>).get(this))
+        }.cleanEmptyValues()
     }
 }

--- a/src/main/kotlin/com/papsign/ktor/openapigen/model/security/SecurityModel.kt
+++ b/src/main/kotlin/com/papsign/ktor/openapigen/model/security/SecurityModel.kt
@@ -1,8 +1,12 @@
 package com.papsign.ktor.openapigen.model.security
 
+import com.papsign.ktor.openapigen.SerializationSettings
+import com.papsign.ktor.openapigen.cleanEmptyValues
+import com.papsign.ktor.openapigen.convertToValue
+import com.papsign.ktor.openapigen.model.DataModel
 import com.papsign.ktor.openapigen.model.Described
 
-class SecurityModel : MutableMap<String, List<*>> by mutableMapOf() {
+class SecurityModel : MutableMap<String, List<*>> by mutableMapOf(), DataModel {
 
     operator fun <T> set(scheme: SecuritySchemeModel<T>, requirements: List<T>) where T: Enum<T>, T: Described {
         this[scheme.name] = requirements
@@ -10,5 +14,12 @@ class SecurityModel : MutableMap<String, List<*>> by mutableMapOf() {
 
     fun <T> set(scheme: SecuritySchemeModel<T>) where T: Enum<T>, T: Described {
         this[scheme] = listOf()
+    }
+
+    override fun serialize(): Map<String, Any?> {
+        val serializationSettings = SerializationSettings(skipEmptyList = true)
+        return this.mapValues { (_, prop) ->
+            convertToValue(prop,serializationSettings)
+        }.cleanEmptyValues(serializationSettings)
     }
 }

--- a/src/main/kotlin/com/papsign/ktor/openapigen/model/security/SecuritySchemeModel.kt
+++ b/src/main/kotlin/com/papsign/ktor/openapigen/model/security/SecuritySchemeModel.kt
@@ -1,7 +1,11 @@
 package com.papsign.ktor.openapigen.model.security
 
+import com.papsign.ktor.openapigen.cleanEmptyValues
+import com.papsign.ktor.openapigen.convertToValue
 import com.papsign.ktor.openapigen.model.DataModel
 import com.papsign.ktor.openapigen.model.Described
+import kotlin.reflect.KProperty1
+import kotlin.reflect.full.memberProperties
 
 data class SecuritySchemeModel<TScope> constructor(
     val type: SecuritySchemeType,
@@ -11,4 +15,11 @@ data class SecuritySchemeModel<TScope> constructor(
     val bearerFormat: String? = null,
     val flows: FlowsModel<TScope>? = null,
     val openIdConnectUrl: String? = null
-): DataModel where TScope : Enum<TScope>, TScope : Described
+): DataModel where TScope : Enum<TScope>, TScope : Described{
+
+    override fun serialize(): Map<String, Any?> {
+        return this::class.memberProperties.associateBy { it.name }.mapValues<String, KProperty1<out SecuritySchemeModel<TScope>, Any?>, Any?> { (_, prop) ->
+            convertToValue((prop as KProperty1<DataModel, *>).get(this))
+        }.filter { it.key != "name" }.cleanEmptyValues()
+    }
+}

--- a/src/test/kotlin/JwtAuthDocumentationGenerationTest.kt
+++ b/src/test/kotlin/JwtAuthDocumentationGenerationTest.kt
@@ -20,12 +20,13 @@ internal class JwtAuthDocumentationGenerationTest {
             assertTrue(response.content!!.contains("\"securitySchemes\" : {\n" +
                     "      \"jwtAuth\" : {\n" +
                     "        \"bearerFormat\" : \"JWT\",\n" +
-                    "        \"name\" : \"jwtAuth\",\n" +
                     "        \"scheme\" : \"bearer\",\n" +
                     "        \"type\" : \"http\"\n" +
                     "      }\n" +
                     "    }"))
-            assertTrue(response.content!!.contains("\"security\" : [ { } ],"))
+            assertTrue(response.content!!.contains("\"security\" : [ {\n" +
+                    "          \"jwtAuth\" : [ ]\n" +
+                    "        } ]"))
         }
     }
 


### PR DESCRIPTION
Hello, this PR adds following improvements:

- proper serialization of SecurityModel in case of bearer ( empty scopes)
- skip "name" field when serializing SecuritySchemeModel

It also adds bit flexibility during serialization:
- basic settings for serailization that includes possibility of serializing empty lists/maps
- possibility to override serialization for nested DataModel

closes #79
closes #68