### PR TITLE
add java.util.Optional support

### DIFF
--- a/src/main/kotlin/com/papsign/ktor/openapigen/parameters/parsers/builders/query/deepobject/DeepBuilderFactory.kt
+++ b/src/main/kotlin/com/papsign/ktor/openapigen/parameters/parsers/builders/query/deepobject/DeepBuilderFactory.kt
@@ -10,5 +10,6 @@ object DeepBuilderFactory : BuilderSelectorFactory<Builder<QueryParamStyle>, Que
     ListDeepBuilder,
     ArrayDeepBuilder,
     MapDeepBuilder,
+    OptionalDeepBuilder,
     ObjectDeepBuilder
 )

--- a/src/main/kotlin/com/papsign/ktor/openapigen/parameters/parsers/builders/query/deepobject/OptionalDeepBuilder.kt
+++ b/src/main/kotlin/com/papsign/ktor/openapigen/parameters/parsers/builders/query/deepobject/OptionalDeepBuilder.kt
@@ -1,0 +1,34 @@
+package com.papsign.ktor.openapigen.parameters.parsers.builders.query.deepobject
+
+import com.papsign.ktor.openapigen.parameters.parsers.builders.BuilderSelector
+import com.papsign.ktor.openapigen.parameters.parsers.converters.Converter
+import com.papsign.ktor.openapigen.parameters.parsers.converters.ConverterFactory
+import java.util.*
+import kotlin.reflect.KType
+import kotlin.reflect.full.isSubclassOf
+import kotlin.reflect.jvm.jvmErasure
+
+class OptionalDeepBuilder(type: KType) : DeepBuilder {
+    private val converter: Converter = ConverterFactory.buildConverterForced(type.arguments[0].type!!)
+
+    override fun build(key: String, parameters: Map<String, List<String>>): Any? {
+        return parameters[key]?.let { it[0] }?.let { value ->
+            when (value) {
+                "" -> Optional.empty()
+                "null" -> Optional.empty()
+                else -> Optional.ofNullable(converter.convert(value))
+            }
+        }
+    }
+
+
+    companion object : BuilderSelector<OptionalDeepBuilder> {
+        override fun canHandle(type: KType, explode: Boolean): Boolean {
+            return type.jvmErasure.isSubclassOf(Optional::class)
+        }
+
+        override fun create(type: KType, explode: Boolean): OptionalDeepBuilder {
+            return OptionalDeepBuilder(type)
+        }
+    }
+}

--- a/src/main/kotlin/com/papsign/ktor/openapigen/parameters/parsers/converters/ConverterFactory.kt
+++ b/src/main/kotlin/com/papsign/ktor/openapigen/parameters/parsers/converters/ConverterFactory.kt
@@ -2,6 +2,7 @@ package com.papsign.ktor.openapigen.parameters.parsers.converters
 
 import com.papsign.ktor.openapigen.parameters.parsers.converters.`object`.MapConverter
 import com.papsign.ktor.openapigen.parameters.parsers.converters.`object`.ObjectConverter
+import com.papsign.ktor.openapigen.parameters.parsers.converters.`object`.OptionalConverter
 import com.papsign.ktor.openapigen.parameters.parsers.converters.collection.ArrayConverter
 import com.papsign.ktor.openapigen.parameters.parsers.converters.collection.ListConverter
 import com.papsign.ktor.openapigen.parameters.parsers.converters.primitive.EnumConverter
@@ -18,6 +19,7 @@ interface ConverterFactory {
         ListConverter,
         ArrayConverter,
         MapConverter,
+        OptionalConverter,
         ObjectConverter
     )
 }

--- a/src/main/kotlin/com/papsign/ktor/openapigen/parameters/parsers/converters/object/OptionalConverter.kt
+++ b/src/main/kotlin/com/papsign/ktor/openapigen/parameters/parsers/converters/object/OptionalConverter.kt
@@ -1,0 +1,32 @@
+package com.papsign.ktor.openapigen.parameters.parsers.converters.`object`
+
+import com.papsign.ktor.openapigen.parameters.parsers.converters.Converter
+import com.papsign.ktor.openapigen.parameters.parsers.converters.ConverterFactory
+import com.papsign.ktor.openapigen.parameters.parsers.converters.ConverterSelector
+import java.util.*
+import kotlin.reflect.KType
+import kotlin.reflect.full.isSubclassOf
+import kotlin.reflect.jvm.jvmErasure
+
+class OptionalConverter(type: KType) : Converter {
+    private val converter: Converter = ConverterFactory.buildConverterForced(type.arguments[0].type!!)
+
+    override fun convert(value: String): Any? {
+        return when (value) {
+            "" -> Optional.empty()
+            "null" -> Optional.empty()
+            else -> Optional.ofNullable(converter.convert(value))
+        }
+    }
+
+
+    companion object : ConverterSelector {
+        override fun canHandle(type: KType): Boolean {
+            return type.jvmErasure.isSubclassOf(Optional::class)
+        }
+
+        override fun create(type: KType): OptionalConverter {
+            return OptionalConverter(type)
+        }
+    }
+}

--- a/src/test/kotlin/com/papsign/ktor/openapigen/parameters/parsers/builder/query/form/OptionalBuilderTest.kt
+++ b/src/test/kotlin/com/papsign/ktor/openapigen/parameters/parsers/builder/query/form/OptionalBuilderTest.kt
@@ -1,0 +1,39 @@
+package com.papsign.ktor.openapigen.parameters.parsers.builder.query.form
+
+import com.papsign.ktor.openapigen.parameters.parsers.builders.query.form.FormBuilderFactory
+import com.papsign.ktor.openapigen.parameters.parsers.testSelector
+import org.junit.Test
+import java.util.*
+
+class OptionalBuilderTest {
+
+    @Test
+    fun testFilledValue() {
+        val key = "key"
+        val expected = Optional.of(1)
+        val parse = mapOf(
+            key to listOf("1")
+        )
+        FormBuilderFactory.testSelector(expected, key, parse, true)
+    }
+
+    @Test
+    fun testEmptyValue() {
+        val key = "key"
+        val expected = Optional.empty<Int>()
+        val parse = mapOf(
+            key to listOf("")
+        )
+        FormBuilderFactory.testSelector(expected, key, parse, true)
+    }
+
+    @Test
+    fun testExplicitNullValue() {
+        val key = "key"
+        val expected = Optional.empty<Int>()
+        val parse = mapOf(
+            key to listOf("null")
+        )
+        FormBuilderFactory.testSelector(expected, key, parse, true)
+    }
+}

--- a/src/test/kotlin/com/papsign/ktor/openapigen/parameters/parsers/builders/query/deepobject/OptionalBuilderTest.kt
+++ b/src/test/kotlin/com/papsign/ktor/openapigen/parameters/parsers/builders/query/deepobject/OptionalBuilderTest.kt
@@ -1,0 +1,38 @@
+package com.papsign.ktor.openapigen.parameters.parsers.builders.query.deepobject
+
+import com.papsign.ktor.openapigen.parameters.parsers.testSelector
+import org.junit.Test
+import java.util.*
+
+class OptionalBuilderTest {
+
+    @Test
+    fun testFilledValue() {
+        val key = "key"
+        val expected = Optional.of(1)
+        val parse = mapOf(
+            key to listOf("1")
+        )
+        DeepBuilderFactory.testSelector(expected, key, parse, true)
+    }
+
+    @Test
+    fun testEmptyValue() {
+        val key = "key"
+        val expected = Optional.empty<Int>()
+        val parse = mapOf(
+            key to listOf("")
+        )
+        DeepBuilderFactory.testSelector(expected, key, parse, true)
+    }
+
+    @Test
+    fun testExplicitNullValue() {
+        val key = "key"
+        val expected = Optional.empty<Int>()
+        val parse = mapOf(
+            key to listOf("null")
+        )
+        DeepBuilderFactory.testSelector(expected, key, parse, true)
+    }
+}


### PR DESCRIPTION
Allow usage `Optional<T>?` in `@QueryParam` 

```
data class OptionalRequest(
    @QueryParam("strictly optional", allowEmptyValues = true) val optInt: Optional<Int>? = null
)
```

Result
/request?optInt=1  > Optional.of(1)
/request?optInt=  > Optional.empty()
/request?optInt=null  > Optional.empty()
/request  > null