### PR TITLE
Add deprecated operation flag into info() function

### DIFF
--- a/src/main/kotlin/com/papsign/ktor/openapigen/route/Info.kt
+++ b/src/main/kotlin/com/papsign/ktor/openapigen/route/Info.kt
@@ -7,16 +7,18 @@ import com.papsign.ktor.openapigen.modules.RouteOpenAPIModule
 import com.papsign.ktor.openapigen.modules.openapi.OperationModule
 
 /**
- * Adds a summary and description for the endpoint being configured
+ * Adds a summary, description and deprecation flag for the endpoint being configured
  */
-fun info(summary: String? = null, description: String? = null) = EndpointInfo(summary, description)
+fun info(summary: String? = null, description: String? = null, deprecated: Boolean? = null) = EndpointInfo(summary, description, deprecated)
 
 data class EndpointInfo(
     val summary: String? = null,
-    val description: String? = null
+    val description: String? = null,
+    val deprecated: Boolean? = null
 ) : OperationModule, RouteOpenAPIModule {
     override fun configure(apiGen: OpenAPIGen, provider: ModuleProvider<*>, operation: OperationModel) {
         operation.description = description
         operation.summary = summary
+        operation.deprecated = deprecated
     }
 }


### PR DESCRIPTION
Right now `OperationModel.deprecated` is unused and cannot be changed without external modules.