### PR TITLE
Added validation error on parsing enum values outside of valid enum values

### DIFF
--- a/src/main/kotlin/com/papsign/ktor/openapigen/annotations/type/enum/StrictEnumParsing.kt
+++ b/src/main/kotlin/com/papsign/ktor/openapigen/annotations/type/enum/StrictEnumParsing.kt
@@ -1,0 +1,5 @@
+package com.papsign.ktor.openapigen.annotations.type.enum
+
+@Target(AnnotationTarget.CLASS)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class StrictEnumParsing

--- a/src/main/kotlin/com/papsign/ktor/openapigen/parameters/parsers/converters/primitive/EnumConverter.kt
+++ b/src/main/kotlin/com/papsign/ktor/openapigen/parameters/parsers/converters/primitive/EnumConverter.kt
@@ -1,19 +1,30 @@
 package com.papsign.ktor.openapigen.parameters.parsers.converters.primitive
 
+import com.papsign.ktor.openapigen.exceptions.OpenAPIBadContentException
 import com.papsign.ktor.openapigen.parameters.parsers.converters.Converter
 import com.papsign.ktor.openapigen.parameters.parsers.converters.ConverterSelector
 import kotlin.reflect.KType
 import kotlin.reflect.jvm.jvmErasure
 
-class EnumConverter(type: KType): Converter {
+class EnumConverter(val type: KType) : Converter {
 
     private val enumMap = type.jvmErasure.java.enumConstants.associateBy { it.toString() }
 
     override fun convert(value: String): Any? {
-        return enumMap[value]
+        if (enumMap.containsKey(value)) {
+            return enumMap[value]
+        } else {
+            throw OpenAPIBadContentException(
+                "Invalid value [$value] for enum parameter of type ${type.jvmErasure.simpleName}. Expected: [${
+                    enumMap.values.joinToString(
+                        ","
+                    )
+                }]"
+            )
+        }
     }
 
-    companion object: ConverterSelector {
+    companion object : ConverterSelector {
         override fun canHandle(type: KType): Boolean {
             return type.jvmErasure.java.isEnum
         }

--- a/src/main/kotlin/com/papsign/ktor/openapigen/parameters/parsers/converters/primitive/EnumConverter.kt
+++ b/src/main/kotlin/com/papsign/ktor/openapigen/parameters/parsers/converters/primitive/EnumConverter.kt
@@ -1,24 +1,30 @@
 package com.papsign.ktor.openapigen.parameters.parsers.converters.primitive
 
+import com.papsign.ktor.openapigen.annotations.type.enum.StrictEnumParsing
 import com.papsign.ktor.openapigen.exceptions.OpenAPIBadContentException
 import com.papsign.ktor.openapigen.parameters.parsers.converters.Converter
 import com.papsign.ktor.openapigen.parameters.parsers.converters.ConverterSelector
+import kotlin.reflect.KClass
 import kotlin.reflect.KType
+import kotlin.reflect.full.findAnnotation
 import kotlin.reflect.jvm.jvmErasure
 
 class EnumConverter(val type: KType) : Converter {
 
+    private val isStrictParsing = (type.classifier as? KClass<*>)?.findAnnotation<StrictEnumParsing>() != null
+
     private val enumMap = type.jvmErasure.java.enumConstants.associateBy { it.toString() }
 
     override fun convert(value: String): Any? {
+        if (!isStrictParsing)
+            return enumMap[value]
+
         if (enumMap.containsKey(value)) {
             return enumMap[value]
         } else {
             throw OpenAPIBadContentException(
                 "Invalid value [$value] for enum parameter of type ${type.jvmErasure.simpleName}. Expected: [${
-                    enumMap.values.joinToString(
-                        ","
-                    )
+                    enumMap.values.joinToString(",")
                 }]"
             )
         }

--- a/src/test/kotlin/com/papsign/ktor/openapigen/EnumStrictTestServer.kt
+++ b/src/test/kotlin/com/papsign/ktor/openapigen/EnumStrictTestServer.kt
@@ -1,0 +1,183 @@
+package com.papsign.ktor.openapigen
+
+import com.papsign.ktor.openapigen.annotations.Path
+import com.papsign.ktor.openapigen.annotations.parameters.QueryParam
+import com.papsign.ktor.openapigen.annotations.type.enum.StrictEnumParsing
+import com.papsign.ktor.openapigen.exceptions.OpenAPIBadContentException
+import com.papsign.ktor.openapigen.exceptions.OpenAPIRequiredFieldException
+import com.papsign.ktor.openapigen.route.apiRouting
+import com.papsign.ktor.openapigen.route.path.normal.get
+import com.papsign.ktor.openapigen.route.response.respond
+import io.ktor.application.*
+import io.ktor.features.*
+import io.ktor.http.*
+import io.ktor.response.*
+import io.ktor.server.testing.*
+import kotlin.test.*
+
+@StrictEnumParsing
+enum class StrictTestEnum {
+    VALID,
+    ALSO_VALID,
+}
+
+@Path("/")
+data class NullableStrictEnumParams(@QueryParam("") val type: StrictTestEnum? = null)
+
+@Path("/")
+data class NonNullableStrictEnumParams(@QueryParam("") val type: StrictTestEnum)
+
+class EnumStrictTestServer {
+
+    companion object {
+        // test server for nullable enums
+        private fun Application.nullableEnum() {
+            install(OpenAPIGen)
+            install(StatusPages) {
+                exception<OpenAPIBadContentException> { e ->
+                    call.respond(HttpStatusCode.BadRequest, e.localizedMessage)
+                }
+            }
+            apiRouting {
+                get<NullableStrictEnumParams, String> { params ->
+                    if (params.type != null)
+                        assertTrue { StrictTestEnum.values().contains(params.type) }
+                    respond(params.type?.toString() ?: "null")
+                }
+            }
+        }
+
+        // test server for non-nullable enums
+        private fun Application.nonNullableEnum() {
+            install(OpenAPIGen)
+            install(StatusPages) {
+                exception<OpenAPIRequiredFieldException> { e ->
+                    call.respond(HttpStatusCode.BadRequest, e.localizedMessage)
+                }
+                exception<OpenAPIBadContentException> { e ->
+                    call.respond(HttpStatusCode.BadRequest, e.localizedMessage)
+                }
+            }
+            apiRouting {
+                get<NonNullableStrictEnumParams, String> { params ->
+                    assertTrue { StrictTestEnum.values().contains(params.type) }
+                    respond(params.type.toString())
+                }
+            }
+        }
+    }
+
+    @Test
+    fun `nullable enum could be omitted and it will be null`() {
+        withTestApplication({ nullableEnum() }) {
+            handleRequest(HttpMethod.Get, "/").apply {
+                assertEquals(HttpStatusCode.OK, response.status())
+                assertEquals("null", response.content)
+            }
+        }
+    }
+
+    @Test
+    fun `nullable enum should be parsed correctly`() {
+        withTestApplication({ nullableEnum() }) {
+            handleRequest(HttpMethod.Get, "/?type=VALID").apply {
+                assertEquals(HttpStatusCode.OK, response.status())
+                assertEquals("VALID", response.content)
+            }
+            handleRequest(HttpMethod.Get, "/?type=ALSO_VALID").apply {
+                assertEquals(HttpStatusCode.OK, response.status())
+                assertEquals("ALSO_VALID", response.content)
+            }
+        }
+    }
+
+    @Test
+    fun `nullable enum parsing should be case-sensitive and should throw on passing wrong case`() {
+        withTestApplication({ nullableEnum() }) {
+            handleRequest(HttpMethod.Get, "/?type=valid").apply {
+                assertEquals(HttpStatusCode.BadRequest, response.status())
+                assertEquals(
+                    "Invalid value [valid] for enum parameter of type StrictTestEnum. Expected: [VALID,ALSO_VALID]",
+                    response.content
+                )
+            }
+            handleRequest(HttpMethod.Get, "/?type=also_valid").apply {
+                assertEquals(HttpStatusCode.BadRequest, response.status())
+                assertEquals(
+                    "Invalid value [also_valid] for enum parameter of type StrictTestEnum. Expected: [VALID,ALSO_VALID]",
+                    response.content
+                )
+            }
+        }
+    }
+
+    @Test
+    fun `nullable enum parsing should not parse values outside of enum`() {
+        withTestApplication({ nullableEnum() }) {
+            handleRequest(HttpMethod.Get, "/?type=what").apply {
+                assertEquals(HttpStatusCode.BadRequest, response.status())
+                assertEquals(
+                    "Invalid value [what] for enum parameter of type StrictTestEnum. Expected: [VALID,ALSO_VALID]",
+                    response.content
+                )
+            }
+        }
+    }
+
+    @Test
+    fun `non-nullable enum cannot be omitted`() {
+        withTestApplication({ nonNullableEnum() }) {
+            handleRequest(HttpMethod.Get, "/").apply {
+                assertEquals(HttpStatusCode.BadRequest, response.status())
+                assertEquals("The field type is required", response.content)
+            }
+        }
+    }
+
+    @Test
+    fun `non-nullable enum should be parsed correctly`() {
+        withTestApplication({ nonNullableEnum() }) {
+            handleRequest(HttpMethod.Get, "/?type=VALID").apply {
+                assertEquals(HttpStatusCode.OK, response.status())
+                assertEquals("VALID", response.content)
+            }
+            handleRequest(HttpMethod.Get, "/?type=ALSO_VALID").apply {
+                assertEquals(HttpStatusCode.OK, response.status())
+                assertEquals("ALSO_VALID", response.content)
+            }
+        }
+    }
+
+    @Test
+    fun `non-nullable enum parsing should be case-sensitive and should throw on passing wrong case`() {
+        withTestApplication({ nonNullableEnum() }) {
+            handleRequest(HttpMethod.Get, "/?type=valid").apply {
+                assertEquals(HttpStatusCode.BadRequest, response.status())
+                assertEquals(
+                    "Invalid value [valid] for enum parameter of type StrictTestEnum. Expected: [VALID,ALSO_VALID]",
+                    response.content
+                )
+            }
+            handleRequest(HttpMethod.Get, "/?type=also_valid").apply {
+                assertEquals(HttpStatusCode.BadRequest, response.status())
+                assertEquals(
+                    "Invalid value [also_valid] for enum parameter of type StrictTestEnum. Expected: [VALID,ALSO_VALID]",
+                    response.content
+                )
+            }
+        }
+    }
+
+    @Test
+    fun `non-nullable enum parsing should not parse values outside of enum`() {
+        withTestApplication({ nonNullableEnum() }) {
+            handleRequest(HttpMethod.Get, "/?type=what").apply {
+                assertEquals(HttpStatusCode.BadRequest, response.status())
+                assertEquals(
+                    "Invalid value [what] for enum parameter of type StrictTestEnum. Expected: [VALID,ALSO_VALID]",
+                    response.content
+                )
+            }
+        }
+    }
+}

--- a/src/test/kotlin/com/papsign/ktor/openapigen/EnumTestServer.kt
+++ b/src/test/kotlin/com/papsign/ktor/openapigen/EnumTestServer.kt
@@ -1,0 +1,181 @@
+package com.papsign.ktor.openapigen
+
+import com.papsign.ktor.openapigen.annotations.Path
+import com.papsign.ktor.openapigen.annotations.parameters.QueryParam
+import com.papsign.ktor.openapigen.exceptions.OpenAPIBadContentException
+import com.papsign.ktor.openapigen.exceptions.OpenAPIRequiredFieldException
+import com.papsign.ktor.openapigen.route.apiRouting
+import com.papsign.ktor.openapigen.route.path.normal.get
+import com.papsign.ktor.openapigen.route.response.respond
+import io.ktor.application.*
+import io.ktor.features.*
+import io.ktor.http.*
+import io.ktor.response.*
+import io.ktor.server.testing.*
+import kotlin.test.*
+
+enum class TestEnum {
+    VALID,
+    ALSO_VALID,
+}
+
+@Path("/")
+data class NullableEnumParams(@QueryParam("") val type: TestEnum? = null)
+
+@Path("/")
+data class NonNullableEnumParams(@QueryParam("") val type: TestEnum)
+
+class EnumTestServer {
+
+    companion object {
+        // test server for nullable enums
+        private fun Application.nullableEnum() {
+            install(OpenAPIGen)
+            install(StatusPages) {
+                exception<OpenAPIBadContentException> { e ->
+                    call.respond(HttpStatusCode.BadRequest, e.localizedMessage)
+                }
+            }
+            apiRouting {
+                get<NullableEnumParams, String> { params ->
+                    if (params.type != null)
+                        assertTrue { TestEnum.values().contains(params.type) }
+                    respond(params.type?.toString() ?: "null")
+                }
+            }
+        }
+
+        // test server for non-nullable enums
+        private fun Application.nonNullableEnum() {
+            install(OpenAPIGen)
+            install(StatusPages) {
+                exception<OpenAPIRequiredFieldException> { e ->
+                    call.respond(HttpStatusCode.BadRequest, e.localizedMessage)
+                }
+                exception<OpenAPIBadContentException> { e ->
+                    call.respond(HttpStatusCode.BadRequest, e.localizedMessage)
+                }
+            }
+            apiRouting {
+                get<NonNullableEnumParams, String> { params ->
+                    assertTrue { TestEnum.values().contains(params.type) }
+                    respond(params.type.toString())
+                }
+            }
+        }
+    }
+
+    @Test
+    fun `nullable enum could be omitted and it will be null`() {
+        withTestApplication({ nullableEnum() }) {
+            handleRequest(HttpMethod.Get, "/").apply {
+                assertEquals(HttpStatusCode.OK, response.status())
+                assertEquals("null", response.content)
+            }
+        }
+    }
+
+    @Test
+    fun `nullable enum should be parsed correctly`() {
+        withTestApplication({ nullableEnum() }) {
+            handleRequest(HttpMethod.Get, "/?type=VALID").apply {
+                assertEquals(HttpStatusCode.OK, response.status())
+                assertEquals("VALID", response.content)
+            }
+            handleRequest(HttpMethod.Get, "/?type=ALSO_VALID").apply {
+                assertEquals(HttpStatusCode.OK, response.status())
+                assertEquals("ALSO_VALID", response.content)
+            }
+        }
+    }
+
+    @Test
+    fun `nullable enum parsing should be case-sensitive and should throw on passing wrong case`() {
+        withTestApplication({ nullableEnum() }) {
+            handleRequest(HttpMethod.Get, "/?type=valid").apply {
+                assertEquals(HttpStatusCode.BadRequest, response.status())
+                assertEquals(
+                    "Invalid value [valid] for enum parameter of type TestEnum. Expected: [VALID,ALSO_VALID]",
+                    response.content
+                )
+            }
+            handleRequest(HttpMethod.Get, "/?type=also_valid").apply {
+                assertEquals(HttpStatusCode.BadRequest, response.status())
+                assertEquals(
+                    "Invalid value [also_valid] for enum parameter of type TestEnum. Expected: [VALID,ALSO_VALID]",
+                    response.content
+                )
+            }
+        }
+    }
+
+    @Test
+    fun `nullable enum parsing should not parse values outside of enum`() {
+        withTestApplication({ nullableEnum() }) {
+            handleRequest(HttpMethod.Get, "/?type=what").apply {
+                assertEquals(HttpStatusCode.BadRequest, response.status())
+                assertEquals(
+                    "Invalid value [what] for enum parameter of type TestEnum. Expected: [VALID,ALSO_VALID]",
+                    response.content
+                )
+            }
+        }
+    }
+
+    @Test
+    fun `non-nullable enum cannot be omitted`() {
+        withTestApplication({ nonNullableEnum() }) {
+            handleRequest(HttpMethod.Get, "/").apply {
+                assertEquals(HttpStatusCode.BadRequest, response.status())
+                assertEquals("The field type is required", response.content)
+            }
+        }
+    }
+
+    @Test
+    fun `non-nullable enum should be parsed correctly`() {
+        withTestApplication({ nonNullableEnum() }) {
+            handleRequest(HttpMethod.Get, "/?type=VALID").apply {
+                assertEquals(HttpStatusCode.OK, response.status())
+                assertEquals("VALID", response.content)
+            }
+            handleRequest(HttpMethod.Get, "/?type=ALSO_VALID").apply {
+                assertEquals(HttpStatusCode.OK, response.status())
+                assertEquals("ALSO_VALID", response.content)
+            }
+        }
+    }
+
+    @Test
+    fun `non-nullable enum parsing should be case-sensitive and should throw on passing wrong case`() {
+        withTestApplication({ nonNullableEnum() }) {
+            handleRequest(HttpMethod.Get, "/?type=valid").apply {
+                assertEquals(HttpStatusCode.BadRequest, response.status())
+                assertEquals(
+                    "Invalid value [valid] for enum parameter of type TestEnum. Expected: [VALID,ALSO_VALID]",
+                    response.content
+                )
+            }
+            handleRequest(HttpMethod.Get, "/?type=also_valid").apply {
+                assertEquals(HttpStatusCode.BadRequest, response.status())
+                assertEquals(
+                    "Invalid value [also_valid] for enum parameter of type TestEnum. Expected: [VALID,ALSO_VALID]",
+                    response.content
+                )
+            }
+        }
+    }
+
+    @Test
+    fun `non-nullable enum parsing should not parse values outside of enum`() {
+        withTestApplication({ nonNullableEnum() }) {
+            handleRequest(HttpMethod.Get, "/?type=what").apply {
+                assertEquals(HttpStatusCode.BadRequest, response.status())
+                assertEquals(
+                    "Invalid value [what] for enum parameter of type TestEnum. Expected: [VALID,ALSO_VALID]",
+                    response.content
+                )
+            }
+        }
+    }
+}

--- a/src/test/kotlin/com/papsign/ktor/openapigen/parameters/parsers/builder/query/form/EnumBuilderTest.kt
+++ b/src/test/kotlin/com/papsign/ktor/openapigen/parameters/parsers/builder/query/form/EnumBuilderTest.kt
@@ -1,5 +1,6 @@
 package com.papsign.ktor.openapigen.parameters.parsers.builder.query.form
 
+import com.papsign.ktor.openapigen.annotations.type.enum.StrictEnumParsing
 import com.papsign.ktor.openapigen.exceptions.OpenAPIBadContentException
 import com.papsign.ktor.openapigen.getKType
 import com.papsign.ktor.openapigen.parameters.parsers.builders.query.form.FormBuilderFactory
@@ -7,10 +8,16 @@ import com.papsign.ktor.openapigen.parameters.parsers.testSelector
 import org.junit.Test
 import kotlin.test.assertFailsWith
 import kotlin.test.assertNotNull
+import kotlin.test.assertNull
 
 class EnumBuilderTest {
 
     enum class TestEnum {
+        A, B, C
+    }
+
+    @StrictEnumParsing
+    enum class StrictTestEnum {
         A, B, C
     }
 
@@ -25,8 +32,25 @@ class EnumBuilderTest {
     }
 
     @Test
-    fun `should throw on enum value outside of enum`() {
+    fun testStrictEnum() {
+        val key = "key"
+        val expected = StrictTestEnum.B
+        val parse = mapOf(
+            key to listOf("B")
+        )
+        FormBuilderFactory.testSelector(expected, key, parse, true)
+    }
+
+    @Test
+    fun `should NOT throw on enum value outside of enum without StrictParsing and return null`() {
         val type = getKType<TestEnum>()
+        val builder = assertNotNull(FormBuilderFactory.buildBuilder(type, true))
+        assertNull(builder.build("key", mapOf("key" to listOf("XXX"))))
+    }
+
+    @Test
+    fun `should throw on enum value outside of enum with StrictParsing`() {
+        val type = getKType<StrictTestEnum>()
         val builder = assertNotNull(FormBuilderFactory.buildBuilder(type, true))
         assertFailsWith<OpenAPIBadContentException> {
             builder.build("key", mapOf("key" to listOf("XXX")))

--- a/src/test/kotlin/com/papsign/ktor/openapigen/parameters/parsers/builder/query/form/EnumBuilderTest.kt
+++ b/src/test/kotlin/com/papsign/ktor/openapigen/parameters/parsers/builder/query/form/EnumBuilderTest.kt
@@ -1,9 +1,12 @@
 package com.papsign.ktor.openapigen.parameters.parsers.builder.query.form
 
-import com.papsign.ktor.openapigen.parameters.parsers.builders.query.deepobject.DeepBuilderFactory
+import com.papsign.ktor.openapigen.exceptions.OpenAPIBadContentException
+import com.papsign.ktor.openapigen.getKType
 import com.papsign.ktor.openapigen.parameters.parsers.builders.query.form.FormBuilderFactory
 import com.papsign.ktor.openapigen.parameters.parsers.testSelector
 import org.junit.Test
+import kotlin.test.assertFailsWith
+import kotlin.test.assertNotNull
 
 class EnumBuilderTest {
 
@@ -19,5 +22,14 @@ class EnumBuilderTest {
             key to listOf("B")
         )
         FormBuilderFactory.testSelector(expected, key, parse, true)
+    }
+
+    @Test
+    fun `should throw on enum value outside of enum`() {
+        val type = getKType<TestEnum>()
+        val builder = assertNotNull(FormBuilderFactory.buildBuilder(type, true))
+        assertFailsWith<OpenAPIBadContentException> {
+            builder.build("key", mapOf("key" to listOf("XXX")))
+        }
     }
 }

--- a/src/test/kotlin/com/papsign/ktor/openapigen/parameters/parsers/builders/query/deepobject/EnumBuilderTest.kt
+++ b/src/test/kotlin/com/papsign/ktor/openapigen/parameters/parsers/builders/query/deepobject/EnumBuilderTest.kt
@@ -1,7 +1,11 @@
 package com.papsign.ktor.openapigen.parameters.parsers.builders.query.deepobject
 
+import com.papsign.ktor.openapigen.exceptions.OpenAPIBadContentException
+import com.papsign.ktor.openapigen.getKType
 import com.papsign.ktor.openapigen.parameters.parsers.testSelector
 import org.junit.Test
+import kotlin.test.assertFailsWith
+import kotlin.test.assertNotNull
 
 class EnumBuilderTest {
 
@@ -17,5 +21,14 @@ class EnumBuilderTest {
             key to listOf("B")
         )
         DeepBuilderFactory.testSelector(expected, key, parse, true)
+    }
+
+    @Test
+    fun `should throw on enum value outside of enum`() {
+        val type = getKType<TestEnum>()
+        val builder = assertNotNull(DeepBuilderFactory.buildBuilder(type, true))
+        assertFailsWith<OpenAPIBadContentException> {
+            builder.build("key", mapOf("key" to listOf("XXX")))
+        }
     }
 }

--- a/src/test/kotlin/com/papsign/ktor/openapigen/parameters/parsers/builders/query/deepobject/EnumBuilderTest.kt
+++ b/src/test/kotlin/com/papsign/ktor/openapigen/parameters/parsers/builders/query/deepobject/EnumBuilderTest.kt
@@ -1,15 +1,22 @@
 package com.papsign.ktor.openapigen.parameters.parsers.builders.query.deepobject
 
+import com.papsign.ktor.openapigen.annotations.type.enum.StrictEnumParsing
 import com.papsign.ktor.openapigen.exceptions.OpenAPIBadContentException
 import com.papsign.ktor.openapigen.getKType
 import com.papsign.ktor.openapigen.parameters.parsers.testSelector
 import org.junit.Test
 import kotlin.test.assertFailsWith
 import kotlin.test.assertNotNull
+import kotlin.test.assertNull
 
 class EnumBuilderTest {
 
     enum class TestEnum {
+        A, B, C
+    }
+
+    @StrictEnumParsing
+    enum class StrictTestEnum {
         A, B, C
     }
 
@@ -24,8 +31,25 @@ class EnumBuilderTest {
     }
 
     @Test
-    fun `should throw on enum value outside of enum`() {
+    fun testStrictEnum() {
+        val key = "key"
+        val expected = StrictTestEnum.B
+        val parse = mapOf(
+            key to listOf("B")
+        )
+        DeepBuilderFactory.testSelector(expected, key, parse, true)
+    }
+
+    @Test
+    fun `should NOT throw on enum value outside of enum without StrictParsing and return null`() {
         val type = getKType<TestEnum>()
+        val builder = assertNotNull(DeepBuilderFactory.buildBuilder(type, true))
+        assertNull(builder.build("key", mapOf("key" to listOf("XXX"))))
+    }
+
+    @Test
+    fun `should throw on enum value outside of enum with StrictParsing`() {
+        val type = getKType<StrictTestEnum>()
         val builder = assertNotNull(DeepBuilderFactory.buildBuilder(type, true))
         assertFailsWith<OpenAPIBadContentException> {
             builder.build("key", mapOf("key" to listOf("XXX")))


### PR DESCRIPTION
It fixes https://github.com/papsign/Ktor-OpenAPI-Generator/issues/111 with throwing `OpenAPIBadContentException` on parsing wrong value.

This validation won't add anything to RouteSelectors, so you have to manually catch error via StatusPage ktor feature to show desired StatusCode and message to the user.
Which I think totally fine because current code throws `OpenAPIRequiredFieldException` on omitting non-nullable query parameter, so this is the same behavior.

# Behavior change 
Assuming we have enum parameter with name `type` and valid values: `[VALID]`


## Nullable
### BEFORE
```
| Route        | StatusCode | Parsed Enum Value     |
|--------------|------------|-----------------------|
| /            | 200        | null                  |
| /?type=VALID | 200        | VALID                 |
| /?type=else  | 200        | null                  |
```
### AFTER
```
| Route        | StatusCode | Parsed Enum Value     |
|--------------|------------|-----------------------|
| /            | 200        | null                  |
| /?type=VALID | 200        | VALID                 |
| /?type=else  | ERROR      |                       | // CHANGED from 200 to ERROR
```
## NON nullable
### BEFORE
```
| Route        | StatusCode | Parsed Enum Value     |
|--------------|------------|-----------------------|
| /            | ERROR      |                       |
| /?type=VALID | 200        | VALID                 |
| /?type=else  | ERROR      |                       |
```
### AFTER
```
| Route        | StatusCode | Parsed Enum Value     |
|--------------|------------|-----------------------|
| /            | ERROR      |                       |
| /?type=VALID | 200        | VALID                 |
| /?type=else  | ERROR      |                       | // CHANGED type of ERROR
```

# ADDED 20 Oct

Added opt-in behaviour to this feature.
Alternative implementations were:

- Add new field to `ParameterModel`. That also would require changes to QueryParam, HeaderParam, PathParam
Pros: These annotations already exist and they could be placed freely on types you don't own
Cons: A lot of changes required in builders.

- Add new annotation which will tell that this enum needs strict parsing
Pros: Really easy to implement
Cons: You have to own the type to annotate with new annotation. Can't put it on 3rd party enums

I've decided to go with the second approach just because I was overwhelmed by amount of changes needed for the first approach.

So in this PR I've added new annotation `StrictEnumParsing` which presence will change behaviour of EnumConverter
Because it is new annotation, no behaviour change for existing code.