### PR TITLE
Added support of name for cookies and query parameters in SecurityScheme

### DIFF
--- a/src/main/kotlin/com/papsign/ktor/openapigen/model/security/SecurityModel.kt
+++ b/src/main/kotlin/com/papsign/ktor/openapigen/model/security/SecurityModel.kt
@@ -9,7 +9,7 @@ import com.papsign.ktor.openapigen.model.Described
 class SecurityModel : MutableMap<String, List<*>> by mutableMapOf(), DataModel {
 
     operator fun <T> set(scheme: SecuritySchemeModel<T>, requirements: List<T>) where T: Enum<T>, T: Described {
-        this[scheme.name] = requirements
+        this[scheme.referenceName] = requirements
     }
 
     fun <T> set(scheme: SecuritySchemeModel<T>) where T: Enum<T>, T: Described {

--- a/src/main/kotlin/com/papsign/ktor/openapigen/model/security/SecuritySchemeModel.kt
+++ b/src/main/kotlin/com/papsign/ktor/openapigen/model/security/SecuritySchemeModel.kt
@@ -9,7 +9,8 @@ import kotlin.reflect.full.memberProperties
 
 data class SecuritySchemeModel<TScope> constructor(
     val type: SecuritySchemeType,
-    val name: String,
+    val referenceName: String,
+    val name: String? = null,
     val `in`: APIKeyLocation? = null,
     val scheme: HttpSecurityScheme? = null,
     val bearerFormat: String? = null,
@@ -20,6 +21,6 @@ data class SecuritySchemeModel<TScope> constructor(
     override fun serialize(): Map<String, Any?> {
         return this::class.memberProperties.associateBy { it.name }.mapValues<String, KProperty1<out SecuritySchemeModel<TScope>, Any?>, Any?> { (_, prop) ->
             convertToValue((prop as KProperty1<DataModel, *>).get(this))
-        }.filter { it.key != "name" }.cleanEmptyValues()
+        }.filter { it.key != "referenceName" }.cleanEmptyValues()
     }
 }

--- a/src/main/kotlin/com/papsign/ktor/openapigen/modules/handlers/AuthHandler.kt
+++ b/src/main/kotlin/com/papsign/ktor/openapigen/modules/handlers/AuthHandler.kt
@@ -14,9 +14,9 @@ object AuthHandler: OperationModule {
         val authHandlers = provider.ofType<AuthProvider<*>>()
         val security = authHandlers.flatMap { it.security }.distinct()
         operation.security = security.map { SecurityModel().also { sec ->
-            it.forEach { sec[it.scheme.name] = it.requirements }
+            it.forEach { sec[it.scheme.referenceName] = it.requirements }
         } }
-        apiGen.api.components.securitySchemes.putAll(security.flatMap { it.map { it.scheme } }.associateBy { it.name })
+        apiGen.api.components.securitySchemes.putAll(security.flatMap { it.map { it.scheme } }.associateBy { it.referenceName })
     }
 
 }

--- a/src/test/kotlin/JwtAuthDocumentationGenerationTest.kt
+++ b/src/test/kotlin/JwtAuthDocumentationGenerationTest.kt
@@ -18,20 +18,26 @@ internal class JwtAuthDocumentationGenerationTest {
             assertEquals(HttpStatusCode.OK, response.status())
             assertTrue(
                 response.content!!.contains(
-                    "\"securitySchemes\" : {\n" +
-                            "      \"jwtAuth\" : {\n" +
-                            "        \"bearerFormat\" : \"JWT\",\n" +
-                            "        \"scheme\" : \"bearer\",\n" +
-                            "        \"type\" : \"http\"\n" +
-                            "      }\n" +
-                            "    }"
+                    """"securitySchemes" : {
+      "ThisIsSchemeName" : {
+        "in" : "cookie",
+        "name" : "ThisIsCookieName",
+        "type" : "apiKey"
+      },
+      "jwtAuth" : {
+        "bearerFormat" : "JWT",
+        "scheme" : "bearer",
+        "type" : "http"
+      }
+    }"""
                 )
             )
             assertTrue(
                 response.content!!.contains(
-                    "\"security\" : [ {\n" +
-                            "          \"jwtAuth\" : [ ]\n" +
-                            "        } ]"
+                    """"security" : [ {
+          "jwtAuth" : [ ],
+          "ThisIsSchemeName" : [ ]
+        }"""
                 )
             )
         }

--- a/src/test/kotlin/TestServerWithJwtAuth.kt
+++ b/src/test/kotlin/TestServerWithJwtAuth.kt
@@ -13,6 +13,7 @@ import com.papsign.ktor.openapigen.annotations.Response
 import com.papsign.ktor.openapigen.annotations.parameters.PathParam
 import com.papsign.ktor.openapigen.annotations.properties.description.Description
 import com.papsign.ktor.openapigen.model.Described
+import com.papsign.ktor.openapigen.model.security.APIKeyLocation
 import com.papsign.ktor.openapigen.model.security.HttpSecurityScheme
 import com.papsign.ktor.openapigen.model.security.SecuritySchemeModel
 import com.papsign.ktor.openapigen.model.security.SecuritySchemeType
@@ -165,7 +166,15 @@ object TestServerWithJwtAuth {
                         SecuritySchemeType.http,
                         scheme = HttpSecurityScheme.bearer,
                         bearerFormat = "JWT",
-                        name = "jwtAuth"
+                        referenceName = "jwtAuth",
+                    ), emptyList<Scopes>()
+                ),
+                AuthProvider.Security(
+                    SecuritySchemeModel(
+                        SecuritySchemeType.apiKey,
+                        `in` = APIKeyLocation.cookie,
+                        name = "ThisIsCookieName",
+                        referenceName = "ThisIsSchemeName",
                     ), emptyList<Scopes>()
                 )
             ))

--- a/src/test/kotlin/com/papsign/ktor/openapigen/routing/GenericRoutesTest.kt
+++ b/src/test/kotlin/com/papsign/ktor/openapigen/routing/GenericRoutesTest.kt
@@ -234,7 +234,7 @@ class GenericRoutesTest {
                 listOf(
                     AuthProvider.Security(
                         SecuritySchemeModel(
-                            name = "basicAuth",
+                            referenceName = "basicAuth",
                             type = SecuritySchemeType.http,
                             scheme = HttpSecurityScheme.basic
                         ), emptyList<Scopes>()


### PR DESCRIPTION
Fixes https://github.com/papsign/Ktor-OpenAPI-Generator/issues/114

# BREAKING CHANGE

Current `name` is used as a "reference" name to refer to that particular scheme in OpenAPI spec (in yaml or json it is key value of the map containing security schemas)

But [spec](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#securitySchemeObject) refers to `name` as a field in that object with very specific semantic
```The name of the header, query or cookie parameter to be used.```

After this change `name` will become what it is supposed to be - name of query/header/cookie, and for "reference" name there is a new required field.

This change will break those, who uses name as "reference" name, but it will bring library closer to OpenAPI spec.